### PR TITLE
Fixes bisection bug in find_next_notification

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -117,9 +117,11 @@ def get_usage_for_account(account):
 
 def find_next_notification(usage):
     members = list(PercentNotified)
+    percentages = [x.to_percentage() for x in members]
+    if usage in percentages:
+        return members[percentages.index(usage)]
 
-    exceeded = [usage > x.to_percentage() for x in members]
-
+    exceeded = [usage > x for x in percentages]
     try:
         index = exceeded.index(False)
         result = PercentNotified.Zero if index == 0 else members[index - 1]


### PR DESCRIPTION
Closes #88 

I've added logic so that the `find_next_notification` function so that a usage of 100% returns a value of 100%. The patch is not the most efficient, but is only temporary anyways. The code in the development branch ultimately removes the function in favor of builtins.