### PR TITLE
Patch inequality error causing accounts to not be locked

### DIFF
--- a/crc_bank.py
+++ b/crc_bank.py
@@ -360,7 +360,7 @@ elif args["check_sus_limit"]:
     percent_usage = 100.0 * used_sus / total_sus
 
     # Lock the account if necessary
-    if percent_usage >= utils.PercentNotified.Hundred and args["<account>"] != "root":
+    if percent_usage >= utils.PercentNotified.Hundred.to_percentage() and args["<account>"] != "root":
         utils.lock_account(args["<account>"])
         utils.log_action(f"The account for {args['<account>']} was locked due to SUs limit")
 


### PR DESCRIPTION
Pull request #91 attempted to fix Issue #88 by moving logic for locking user accounts earlier in the control flow.

It looks like the logic that was moved up had yet another bug:

```
    if percent_usage >= utils.PercentNotified.Hundred and args["<account>"] != "root":
TypeError: '>=' not supported between instances of 'float' and 'PercentNotified'
```

Unfortunately this wasn't caught by human inspection, and there is no (fully functioning) test suite to run master against. 
This PR fixes the above issue.