### PR TITLE
Init SlurmAccount instances only when necessary

### DIFF
--- a/bank/cli.py
+++ b/bank/cli.py
@@ -141,23 +141,23 @@ class AccountParser(BaseParser):
         """
 
         # Reusable definitions for arguments
-        account_argument = dict(metavar='acc', help='Name of a slurm user account', required=True)
+        account_argument = dict(metavar='acc', dest='self',  type=AccountServices, help='Name of a slurm user account', required=True)
 
         lock_parser = parent_parser.add_parser('lock', help='Lock a slurm account from submitting any jobs')
-        lock_parser.set_defaults(function=lambda account: SlurmAccount(account).set_locked_state(True))
+        lock_parser.set_defaults(function=AccountServices.lock_account)
         lock_parser.add_argument('--account', **account_argument)
 
         unlock_parser = parent_parser.add_parser('unlock', help='Allow a slurm account to resume submitting jobs')
-        unlock_parser.set_defaults(function=lambda account: SlurmAccount(account).set_locked_state(False))
+        unlock_parser.set_defaults(function=AccountServices.unlock_account)
         unlock_parser.add_argument('--account', **account_argument)
 
         renew_parser = parent_parser.add_parser('renew', help='Renew an account\'s proposal and rollover any is_expired investments')
         renew_parser.set_defaults(function=AccountServices.renew)
-        renew_parser.add_argument('--account', **account_argument, dest='self', type=AccountServices)
+        renew_parser.add_argument('--account', **account_argument)
 
         info_parser = parent_parser.add_parser('info', help='Print account usage and allocation information')
         info_parser.set_defaults(function=AccountServices.print_info)
-        info_parser.add_argument('--account', **account_argument, dest='self', type=AccountServices)
+        info_parser.add_argument('--account', **account_argument)
 
 
 class ProposalParser(BaseParser):


### PR DESCRIPTION
Some of the CLI tests were failing because `SlurmAccount` objects were being instantiated early in the logic flow. This is problematic because slurm is not available in the CI testing environment. 

This PR refactors the code to move class instantiation later in the logic flow so it is never called during the execution of the CLI tests.