### PR TITLE
Enable pip extras in setup.py

### DIFF
--- a/.github/workflows/DeployDocs.yml
+++ b/.github/workflows/DeployDocs.yml
@@ -18,8 +18,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -r docs/requirements.txt
+          pip install .[docs]
 
       - name: Build and commit
         uses: sphinx-notes/pages@master

--- a/.github/workflows/TestDocs.yml
+++ b/.github/workflows/TestDocs.yml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -r docs/requirements.txt
+          pip install .[docs]
 
       # This will intentionally fail if docs do not build successfully
       - name: Run doctest

--- a/.github/workflows/Unittests.yml
+++ b/.github/workflows/Unittests.yml
@@ -23,10 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install package dependencies
-        run: pip install .
-
-      - name: Install test dependencies
-        run: pip install coverage
+        run: pip install .[tests]
 
       - name: Run tests with coverage
         run: |

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
+PACKAGE_REQUIREMENTS = Path(__file__).parent / 'requirements.txt'
+DOCUMENTATION_REQUIREMENTS = Path(__file__).parent / 'docs' / 'requirements.txt'
+
 
 def get_long_description():
     """Return a long description of tha parent package"""
@@ -13,11 +16,10 @@ def get_long_description():
     return readme_file.read_text()
 
 
-def get_requirements():
+def get_requirements(path):
     """Return a list of package dependencies"""
 
-    requirements_path = Path(__file__).parent / 'requirements.txt'
-    with requirements_path.open() as req_file:
+    with path.open() as req_file:
         return req_file.read().splitlines()
 
 
@@ -54,7 +56,11 @@ setup(
         [console_scripts]
         crc-bank=bank.cli:CommandLineApplication.execute
     """,
-    install_requires=get_requirements(),
+    install_requires=get_requirements(PACKAGE_REQUIREMENTS),
+    extras_require={
+        'docs': get_requirements(DOCUMENTATION_REQUIREMENTS),
+        'tests': ['coverage'],
+    },
     author=_author,
     keywords='Pitt, CRC, HPC',
     long_description=get_long_description(),


### PR DESCRIPTION
Adds support for the following installation options:

```bash
pip install .[docs]
pip install .[tests]
```