### PR TITLE
Update Investment Application Logic

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -447,7 +447,7 @@ class InvestmentServices:
         if (start and end) and start > end:
             raise ValueError('``start`` needs to be a date before ``end``')
 
-        inv_id = inv_id or self._get_active_inv_id()
+        inv_id = inv_id or self._get_active_investment_id()
 
         self._verify_investment_id(inv_id)
 
@@ -486,7 +486,7 @@ class InvestmentServices:
 
         self._verify_service_units(sus)
 
-        inv_id = inv_id or self._get_active_inv_id()
+        inv_id = inv_id or self._get_active_investment_id()
         self._verify_investment_id(inv_id)
 
         query = select(Investment).where(Investment.id == inv_id)
@@ -515,7 +515,7 @@ class InvestmentServices:
 
         self._verify_service_units(sus)
 
-        inv_id = inv_id or self._get_active_inv_id()
+        inv_id = inv_id or self._get_active_investment_id()
         self._verify_investment_id(inv_id)
 
         query = select(Investment).where(Investment.id == inv_id)
@@ -542,7 +542,7 @@ class InvestmentServices:
         """
 
         self._verify_service_units(sus)
-        inv_id = self._get_active_inv_id()
+        inv_id = self._get_active_investment_id()
         requested_withdrawal = sus
 
         with DBConnection.session() as session:

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -304,7 +304,7 @@ class InvestmentServices:
 
         with DBConnection.session() as session:
 
-        # Determine the active investment ID
+            # Determine the active investment ID
             active_inv_id_query = select(Investment.id) \
                 .join(Account) \
                 .where(Account.name == self._account_name) \
@@ -370,7 +370,7 @@ class InvestmentServices:
 
         if not end:
             end = start + relativedelta(months=12)
-        if start > end:
+        if start >= end:
             raise ValueError(f'Argument start: {start} must be an earlier date than than end: {end}')
 
         if num_inv < 1:
@@ -440,8 +440,10 @@ class InvestmentServices:
 
         # Validate Arguments
         if not (start or end):
-            raise ValueError(f'modify_date requires either a new start: {start} or new end: {end} date')
-        if (start and end) and start > end:
+            print('No start or end provided, nothing changed')
+            return
+
+        if (start and end) and start >= end:
             raise ValueError(f'start: {start} needs to be a date before end: {end}')
 
         inv_id = inv_id or self._get_active_investment_id()

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -94,7 +94,7 @@ class ProposalServices:
     def create_proposal(
             self,
             start: date = date.today(),
-            duration: int = 12,
+            duration: int = 365,
             **kwargs: int
     ) -> None:
         """Create a new proposal for the account
@@ -108,8 +108,7 @@ class ProposalServices:
 
         with DBConnection.session() as session:
             # Make sure new proposal does not overlap with existing proposals
-            expiration_date = start + relativedelta(months=12)
-            last_active_day = expiration_date - timedelta(days=1)
+            last_active_day = start + timedelta(days=duration - 1)
             overlapping_proposal_query = select(Proposal).join(Account) \
                 .where(Account.name == self._account_name) \
                 .where(
@@ -128,7 +127,7 @@ class ProposalServices:
             new_proposal = Proposal(
                 percent_notified=0,
                 start_date=start,
-                end_date=expiration_date,
+                end_date=start + timedelta(days=duration),
                 allocations=[
                     Allocation(cluster_name=cluster, service_units=sus) for cluster, sus in kwargs.items()
                 ]

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -316,7 +316,7 @@ class InvestmentServices:
                 raise MissingInvestmentError(f'Account `{self._account_name}` has no active investment.')
             return active_inv_id
 
-    def _validate_investment_id(self, inv_id: int) -> None:
+    def _verify_investment_id(self, inv_id: int) -> None:
         """Raise an error if a given ID does not belong to the current account
 
         Args:
@@ -332,7 +332,7 @@ class InvestmentServices:
                 raise MissingInvestmentError(f'Account `{self._account_name}` has no investment with ID {inv_id}.')
 
     @staticmethod
-    def _validate_service_units(sus: int) -> None:
+    def _verify_service_units(sus: int) -> None:
         """Raise an error if given service units are invalid
 
         Args:

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -436,7 +436,9 @@ class InvestmentServices:
             end: Optionally set a new end date for the investment
 
         Raises:
-            MissingInvestmentError: If the account does not have a proposal
+            MissingInvestmentError: If the account does not have an investment
+            ValueError: If neither a start date or end date are provided, and if provided start/end dates are not in
+            chronological order with amongst themselves or with the existing DB values.
         """
 
         # Validate Arguments
@@ -462,7 +464,7 @@ class InvestmentServices:
                     f'If providing ``end`` alone, it needs to be later than the current start date: {investment.start_date}')
 
             # Make provided changes
-            if start
+            if start:
                 investment.start_date = start
                 LOG.info('Overwriting start date on investment %s for account %s', investment.id, self._account_name)
             if end:

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -419,7 +419,7 @@ class InvestmentServices:
         """Overwrite the start or end date of a given investment
 
         Args:
-            inv_id: The id of the investment to change, default is the active investment
+            inv_id: The ID of the investment to change, default is the active investment ID
             start: Optionally set a new start date for the investment
             end: Optionally set a new end date for the investment
 
@@ -444,11 +444,12 @@ class InvestmentServices:
 
             session.commit()
 
-    def add_sus(self, inv_id: int, sus: int) -> None:
+
+    def add_sus(self, inv_id: Optional[int], sus: int) -> None:
         """Add service units to the given investment
 
         Args:
-            inv_id: The id of the investment to change
+            inv_id: The ID of the investment to change, default is the active investment ID
             sus: Number of service units to add
 
         Raises:
@@ -456,6 +457,8 @@ class InvestmentServices:
         """
 
         self._verify_service_units(sus)
+
+        inv_id = inv_id or self._get_active_inv_id()
         self._verify_investment_id(inv_id)
 
         query = select(Investment).where(Investment.id == inv_id)
@@ -467,11 +470,11 @@ class InvestmentServices:
             session.commit()
             LOG.info(f'Added {sus} service units to investment {investment.id} for account {self._account_name}')
 
-    def subtract_sus(self, inv_id: int, sus: int) -> None:
+    def subtract_sus(self, inv_id: Optional[int], sus: int) -> None:
         """Subtract service units from the given investment
 
         Args:
-            inv_id: The inv_id of the investment to change
+            inv_id: The ID of the investment to change, default is the active investment ID
             sus: Number of service units to remove
 
         Raises:
@@ -479,6 +482,8 @@ class InvestmentServices:
         """
 
         self._verify_service_units(sus)
+
+        inv_id = inv_id or self._get_active_inv_id()
         self._verify_investment_id(inv_id)
 
         query = select(Investment).where(Investment.id == inv_id)

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -341,7 +341,7 @@ class InvestmentServices:
             ValueError: If service units are not positive
         """
 
-        if sus <= 0:
+        if int(sus) <= 0:
             raise ValueError('Service units must be greater than zero.')
 
     def create(
@@ -453,20 +453,20 @@ class InvestmentServices:
         query = select(Investment).where(Investment.id == inv_id)
         with DBConnection.session() as session:
             investment = session.execute(query).scalars().first()
+            start = start or investment.start_date
+            end = end or investment.end_date
 
             # Validate provided start/end against DB entries
-            if (start and not end) and start > investment.end_date:
+            if start >= end:
                 raise ValueError(
-                    f'If providing start alone, it needs to be earlier than the current end date: {investment.end_date}')
-            if (end and not start) and end < investment.start_date:
-                raise ValueError(
-                    f'If providing end alone, it needs to be later than the current start date: {investment.start_date}')
+                    f'If providing start or end alone, they need to be values that make chronological sense: {start} >= {end}')
 
             # Make provided changes
-            if start:
+            if start != investment.start_date:
                 investment.start_date = start
                 LOG.info(f"Overwriting start date on investment {investment.id} for account {self._account_name}")
-            if end:
+
+            if end != investment.end_date:
                 investment.end_date = end
                 LOG.info(f"Overwriting end date on investment {investment.id} for account {self._account_name}")
 

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -140,7 +140,7 @@ class ProposalServices:
 
             session.add(account)
             session.commit()
-            LOG.info('Created proposal %d for %s', new_proposal.id, self._account_name)
+            LOG.info(f'Created proposal {new_proposal.id} for {self._account_name}')
 
     def delete_proposal(self, pid: Optional[int] = None) -> None:
         """Delete a proposal from the current account
@@ -159,7 +159,7 @@ class ProposalServices:
             session.execute(delete(Proposal).where(Proposal.id == pid))
             session.execute(delete(Allocation).where(Allocation.proposal_id == pid))
             session.commit()
-            LOG.info('Deleted proposal %d for %s', pid, self._account_name)
+            LOG.info(f'Deleted proposal {pid} for {self._account_name}')
 
     def modify_proposal(
             self,
@@ -399,15 +399,11 @@ class InvestmentServices:
                 account = session.execute(select(Account).where(Account.name == self._account_name)).scalars().first()
                 account.investments.append(new_investment)
                 session.add(account)
-                LOG.debug(
-                    'Inserting investment %d for %s with %d service units',
-                    new_investment.id,
-                    self._account_name,
-                    sus)
+                LOG.debug(f"Inserting investment {new_investment.id} for {self._account_name} with {sus} service units")
 
                 session.commit()
 
-            LOG.info('Invested %d service units for account %s', sus, self._account_name)
+            LOG.info(f"Invested {sus} service units for account {self._account_name}")
 
     def delete(self, inv_id: int) -> None:
         """Delete one of the account's associated investments
@@ -426,7 +422,7 @@ class InvestmentServices:
         with DBConnection.session() as session:
             session.execute(delete(Investment).where(Investment.id == inv_id))
             session.commit()
-            LOG.info('Deleted investment %d for %s', inv_id, self._account_name)
+            LOG.info(f"Deleted investment {inv_id} for {self._account_name}")
 
     def modify_date(self, inv_id: Optional[int] = None, start: Optional[date] = None, end: Optional[date] = None) -> None:
         """Overwrite the start or end date of a given investment
@@ -467,10 +463,10 @@ class InvestmentServices:
             # Make provided changes
             if start:
                 investment.start_date = start
-                LOG.info('Overwriting start date on investment %s for account %s', investment.id, self._account_name)
+                LOG.info(f"Overwriting start date on investment {investment.id} for account {self._account_name}")
             if end:
                 investment.end_date = end
-                LOG.info('Overwriting end date on investment %s for account %s', investment.id, self._account_name)
+                LOG.info(f"Overwriting end date on investment {investment.id} for account {self._account_name}")
 
             session.commit()
 
@@ -497,11 +493,7 @@ class InvestmentServices:
             investment.current_sus += sus
 
             session.commit()
-            LOG.info(
-                'Added %d service units to investment %d for account %s',
-                sus,
-                investment.id,
-                self._account_name)
+            LOG.info(f"Added {sus} service units to investment {investment.id} for account {self._account_name}")
 
     def subtract_sus(self, inv_id: Optional[int], sus: int) -> None:
         """Subtract service units from the given investment
@@ -530,10 +522,7 @@ class InvestmentServices:
             investment.current_sus -= sus
 
             session.commit()
-            LOG.info(
-                'Removed %d service units from investment %d for account %s',
-                sus,
-                investment.id, self._account_name)
+            LOG.info(f"Removed {sus} service units from investment {investment.id} for account {self._account_name}")
 
     def advance(self, sus: int) -> None:
         """Withdraw service units from future investments
@@ -575,7 +564,7 @@ class InvestmentServices:
                 maximum_withdrawal = investment.service_units - investment.withdrawn_sus
                 to_withdraw = min(sus, maximum_withdrawal)
 
-                LOG.info('Withdrawing %d service units from investment %d', to_withdraw, investment.id)
+                LOG.info(f"Withdrawing {to_withdraw} service units from investment {investment.id}")
                 investment.current_sus -= to_withdraw
                 investment.withdrawn_sus += to_withdraw
                 active_investment.current_sus += to_withdraw
@@ -587,7 +576,7 @@ class InvestmentServices:
 
             session.commit()
 
-        LOG.info('Advanced %d service units for account %s', (requested_withdrawal - sus), self._account_name)
+        LOG.info(f"Advanced {(requested_withdrawal - sus)} service units for account {self._account_name}")
 
 
 class AccountServices:

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -371,11 +371,11 @@ class InvestmentServices:
 
         if not end:
             end = start + relativedelta(months=12)
-        if start < end:
-            raise ValueError('Argument ``start`` must be an earlier date than than ``end``')
+        if start > end:
+            raise ValueError(f'Argument start: {start} must be an earlier date than than end: {end}')
 
         if num_inv < 1:
-            raise ValueError('Argument ``repeat`` must be >= 1')
+            raise ValueError(f'Argument num_inv: {num_inv} must be >= 1')
 
         # Calculate number of service units per each investment
         duration = relativedelta(end,start)
@@ -444,10 +444,10 @@ class InvestmentServices:
         """
 
         # Validate Arguments
-        if not start or end:
-            raise ValueError('``modify_date`` requires either a new ``start`` or new ``end`` date')
+        if not (start or end):
+            raise ValueError(f'modify_date requires either a new start: {start} or new end: {end} date')
         if (start and end) and start > end:
-            raise ValueError('``start`` needs to be a date before ``end``')
+            raise ValueError(f'start: {start} needs to be a date before end: {end}')
 
         inv_id = inv_id or self._get_active_investment_id()
 
@@ -460,10 +460,10 @@ class InvestmentServices:
             # Validate provided start/end against DB entries
             if (start and not end) and start > investment.end_date:
                 raise ValueError(
-                    f'If providing ``start`` alone, it needs to be earlier than the current end date: {investment.end_date}')
+                    f'If providing start alone, it needs to be earlier than the current end date: {investment.end_date}')
             if (end and not start) and end < investment.start_date:
                 raise ValueError(
-                    f'If providing ``end`` alone, it needs to be later than the current start date: {investment.start_date}')
+                    f'If providing end alone, it needs to be later than the current start date: {investment.start_date}')
 
             # Make provided changes
             if start:

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -345,11 +345,11 @@ class InvestmentServices:
         if sus <= 0:
             raise ValueError('Service units must be greater than zero.')
 
-    def create_investment(
+    def create(
         self,
         sus: int,
         start: Optional[date] = date.today(),
-        end: Optional[date] = start + relativedelta(months=12),
+        end: Optional[date] = None,
         num_inv: Optional[int] = 1) -> None:
         """Add a new investment or series of investments to the given account
 
@@ -369,6 +369,8 @@ class InvestmentServices:
         # Validate arguments
         self._verify_service_units(sus)
 
+        if not end:
+            end = start + relativedelta(months=12)
         if start < end:
             raise ValueError('Argument ``start`` must be an earlier date than than ``end``')
 
@@ -408,7 +410,7 @@ class InvestmentServices:
 
             LOG.info('Invested %d service units for account %s', sus, self._account_name)
 
-    def delete_investment(self, inv_id: int) -> None:
+    def delete(self, inv_id: int) -> None:
         """Delete one of the account's associated investments
 
         Args:

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -410,18 +410,16 @@ class InvestmentServices:
             session.commit()
             LOG.info(f"Deleted investment {inv_id} for {self._account_name}")
 
-    def modify_investment(
+    def modify_date(
             self,
             inv_id: Optional[int] = None,
-            sus: Optional[int] = None,
             start: Optional[date] = None,
             end: Optional[date] = None
     ) -> None:
-        """Overwrite service units allocated to the given investment
+        """Overwrite the start or end date of a given investment
 
         Args:
-            inv_id: The id of the investment to change
-            sus: New number of service units to assign to the investment
+            inv_id: The id of the investment to change, default is the active investment
             start: Optionally set a new start date for the investment
             end: Optionally set a new end date for the investment
 
@@ -432,25 +430,19 @@ class InvestmentServices:
         inv_id = inv_id or self._get_active_inv_id()
         self._verify_investment_id(inv_id)
 
-        if sus:
-            self._verify_service_units(sus)
-
         query = select(Investment).where(Investment.id == inv_id)
         with DBConnection.session() as session:
             investment = session.execute(query).scalars().first()
 
-            if sus is not None:
-                self._verify_service_units(sus)
-                investment.service_units = sus
-
             if start:
                 investment.start_date = start
+                LOG.info('Overwriting start date on investment %s for account %s', investment.id, self._account_name)
 
             if end:
                 investment.end_date = end
+                LOG.info('Overwriting end date on investment %s for account %s', investment.id, self._account_name)
 
             session.commit()
-            LOG.info(f'Overwrote service units on investment {investment.id} to {sus} for account {self._account_name}')
 
     def add_sus(self, inv_id: int, sus: int) -> None:
         """Add service units to the given investment

--- a/bank/cli.py
+++ b/bank/cli.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 
 import abc
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, ArgumentTypeError
 from datetime import datetime
 from typing import Type
 
@@ -96,7 +96,6 @@ class BaseParser(ArgumentParser):
     @staticmethod
     def valid_date(date_string: str) -> datetime.date():
         """Print a useful error if the user provided date does not conform to `settings.date_format`."""
-
         date = datetime.strptime(date_string, settings.date_format).date()
 
         return date
@@ -105,8 +104,8 @@ class BaseParser(ArgumentParser):
     def non_negative_int(number: int) -> int:
         """Print an error if a negative integer is supplied to applicable arguments."""
 
-        if number < 0:
-            raise ValueError("The value provided can not be negative")
+        if int(number) < 0:
+            raise ArgumentTypeError(f"{number} is negative. SUs must be a positive integer")
 
         return number
 

--- a/bank/cli.py
+++ b/bank/cli.py
@@ -412,7 +412,7 @@ class InvestmentParser(BaseParser):
             'modify_date',
             help='Modify the start or end date of an existing investment'
         )
-        modify_date_parser.set_defaults(function=InvestmentServices.modify_investment)
+        modify_date_parser.set_defaults(function=InvestmentServices.modify_date)
         modify_date_parser.add_argument(**account_definition)
         modify_date_parser.add_argument('--ID', **investment_id_definition)
         modify_date_parser.add_argument(

--- a/bank/cli.py
+++ b/bank/cli.py
@@ -249,7 +249,7 @@ class ProposalParser(BaseParser):
         create_parser.add_argument(**account_definition)
         create_parser.add_argument(
             '--start',
-            type=lambda date: datetime.strptime(date, settings.date_format).date(),
+            type=cls.valid_date,
             default=datetime.today(),
             help=(
                 'Start date for the proposal, '
@@ -290,7 +290,7 @@ class ProposalParser(BaseParser):
         modify_date_parser.add_argument(**account_definition)
         modify_date_parser.add_argument(
             '--start',
-            type=(lambda date: datetime.strptime(date, settings.date_format).date()),
+            type=cls.valid_date,
             help=(
                 'Set a new proposal start date, '
                 f'format: {datetime.strftime(datetime.today(), settings.date_format)}'
@@ -298,7 +298,7 @@ class ProposalParser(BaseParser):
         )
         modify_date_parser.add_argument(
             '--end',
-            type=lambda date: datetime.strptime(date, settings.date_format).date(),
+            type=cls.valid_date,
             help=(
                 'Set a new proposal end date, '
                 f'format: {datetime.strftime(datetime.today(), settings.date_format)}'

--- a/bank/cli.py
+++ b/bank/cli.py
@@ -217,6 +217,7 @@ class ProposalParser(BaseParser):
         account_definition = dict(
             dest='self',
             metavar='account',
+            type=ProposalServices,
             help='The parent slurm account'
         )
         proposal_id_definition = dict(
@@ -330,6 +331,7 @@ class InvestmentParser(BaseParser):
         account_definition = dict(
             dest='self',
             metavar='account',
+            type=InvestmentServices,
             help='The parent slurm account'
         )
         investment_id_definition = dict(
@@ -352,11 +354,12 @@ class InvestmentParser(BaseParser):
         create_parser.add_argument(**account_definition)
         create_parser.add_argument('--SUs', **service_unit_definition)
         create_parser.add_argument(
-            '--repeat',
-            metavar='REP',
-            type=int,
+            '--disbursements',
+            dest='disbursements',
+            metavar='N',
+            type=lambda N: (int(N) > 0) and int(N),
             default=5,
-            help='Divide the service units across REP sequential investments'
+            help='Divide the service units across N sequential investments'
         )
         create_parser.add_argument(
             '--start',

--- a/bank/cli.py
+++ b/bank/cli.py
@@ -361,12 +361,11 @@ class InvestmentParser(BaseParser):
 
         # Investment Creation
         create_parser = parent_parser.add_parser('create', help='Create a new investment')
-        create_parser.set_defaults(function=InvestmentServices.create_investment)
+        create_parser.set_defaults(function=InvestmentServices.create)
         create_parser.add_argument(**account_definition)
         create_parser.add_argument('--SUs', **service_unit_definition)
         create_parser.add_argument(
-            '--disbursements',
-            dest='disbursements',
+            '--num_inv',
             metavar='N',
             type=lambda N: (int(N) > 0) and int(N),
             default=5,
@@ -382,11 +381,17 @@ class InvestmentParser(BaseParser):
                 f'format: {datetime.strftime(datetime.today(), settings.date_format)}, the default is today'
             )
         )
-        create_parser.add_argument('--duration', type=int, default=12, help='The length of each investment in months')
+        create_parser.add_argument(
+            '--end',
+            metavar=f'{settings.date_format}',
+            type=lambda date: cls.valid_date(date),
+            help=('The expiration date of the investment / first investment in a series. The default is a year '
+                  'from the start date')
+        )
 
         # Investment Deletion
         delete_parser = parent_parser.add_parser('delete', help='Delete an existing investment')
-        delete_parser.set_defaults(function=InvestmentServices.delete_investment)
+        delete_parser.set_defaults(function=InvestmentServices.delete)
         delete_parser.add_argument(**account_definition)
         delete_parser.add_argument('--ID', **investment_id_definition, required=True)
 

--- a/bank/exceptions.py
+++ b/bank/exceptions.py
@@ -40,6 +40,3 @@ class MissingInvestmentError(Exception):
 
 class InvestmentExistsError(Exception):
     """Raised when trying to create an investment that already exists."""
-
-class BadDateFormatError(Exception):
-    """Raised when the date provided is in the incorrect format."""

--- a/bank/exceptions.py
+++ b/bank/exceptions.py
@@ -40,3 +40,6 @@ class MissingInvestmentError(Exception):
 
 class InvestmentExistsError(Exception):
     """Raised when trying to create an investment that already exists."""
+
+class BadDateFormatError(Exception):
+    """Raised when the date provided is in the incorrect format."""

--- a/tests/account_logic/test_InvestmentServices.py
+++ b/tests/account_logic/test_InvestmentServices.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest import TestCase
 
 from sqlalchemy import select
@@ -33,7 +33,7 @@ class CreateInvestment(ProposalSetup, TestCase):
         """Test a new investment is added to the account after the function call"""
 
         account = InvestmentServices(settings.test_account)
-        account.create_investment(sus=12345)
+        account.create(sus=12345)
 
         with DBConnection.session() as session:
             investments = session.execute(investments_query).scalars().all()
@@ -44,19 +44,19 @@ class CreateInvestment(ProposalSetup, TestCase):
         """Test an error is raised when creating an investment with non-positive sus"""
 
         with self.assertRaises(ValueError):
-            InvestmentServices(settings.test_account).create_investment(sus=0)
+            InvestmentServices(settings.test_account).create(sus=0)
 
         with self.assertRaises(ValueError):
-            InvestmentServices(settings.test_account).create_investment(sus=-1)
+            InvestmentServices(settings.test_account).create(sus=-1)
 
     def test_error_on_nonpositive_repeate(self) -> None:
         """Test an error is raised when creating an investment with less than one repeat"""
 
         with self.assertRaises(ValueError):
-            InvestmentServices(settings.test_account).create_investment(sus=1000, num_inv=0)
+            InvestmentServices(settings.test_account).create(sus=1000, num_inv=0)
 
         with self.assertRaises(ValueError):
-            InvestmentServices(settings.test_account).create_investment(sus=1000, num_inv=-1)
+            InvestmentServices(settings.test_account).create(sus=1000, num_inv=-1)
 
     def test_investment_is_repeated(self) -> None:
         """Test the given number of investments are created successively"""
@@ -64,26 +64,33 @@ class CreateInvestment(ProposalSetup, TestCase):
         test_sus = 2000
         repeats = 2
         account = InvestmentServices(settings.test_account)
-        account.create_investment(sus=test_sus, num_inv=repeats)
+        account.create(sus=test_sus, num_inv=repeats)
 
         with DBConnection.session() as session:
             investments = session.execute(investments_query).scalars().all()
             total_sus = sum(inv.current_sus for inv in investments)
 
-            self.assertEqual(repeats, len(investments), f'Expected {repeats} investments to be created but found {len(investments)}')
+            self.assertEqual(
+                repeats,
+                len(investments),
+                f'Expected {repeats} investments to be created but found {len(investments)}')
             self.assertEqual(test_sus, total_sus)
 
 
 class DeleteInvestment(ProposalSetup, InvestmentSetup, TestCase):
+    """Tests the deletion of investments with ``delete``"""
 
     def test_investment_is_deleted(self) -> None:
+        """Test the deletion of a single investment"""
+
         with DBConnection.session() as session:
             investment = session.execute(primary_investment_query).scalars().first()
             primary_id = investment.id
 
-        InvestmentServices(settings.test_account).delete_investment(primary_id)
+        InvestmentServices(settings.test_account).delete(primary_id)
         with DBConnection.session() as session:
             investment = session.execute(primary_investment_query).scalars().first()
+
             self.assertIsNone(investment)
 
 
@@ -145,30 +152,8 @@ class SubtractSus(ProposalSetup, InvestmentSetup, TestCase):
             InvestmentServices(settings.test_account).subtract_sus(1, self.num_inv_sus + 1000)
 
 
-class OverwriteSus(ProposalSetup, InvestmentSetup, TestCase):
-    """Test the modification of allocated sus via the ``set_cluster_allocation`` method"""
-
-    def test_sus_are_modified(self) -> None:
-        """Test sus are overwritten in the investment"""
-
-        investment_query = select(Investment).join(Account) \
-            .where(Account.name == settings.test_account) \
-            .order_by(Investment.start_date.desc())
-
-        with DBConnection.session() as session:
-            old_investment = session.execute(investment_query).scalars().first()
-            investment_id = old_investment.id
-            old_start_date = old_investment.start_date
-            old_end_date = old_investment.end_date
-
-        sus_to_overwrite = 10
-        InvestmentServices(settings.test_account).modify_investment(investment_id, sus_to_overwrite)
-
-        with DBConnection.session() as session:
-            new_investment = session.execute(investment_query).scalars().first()
-            self.assertEqual(sus_to_overwrite, new_investment.service_units)
-            self.assertEqual(old_start_date, new_investment.start_date)
-            self.assertEqual(old_end_date, new_investment.end_date)
+class ModifyDate(ProposalSetup, InvestmentSetup, TestCase):
+    """Test the modification of investment dates via modify_date"""
 
     def test_dates_are_modified(self) -> None:
         """Test start and end dates are overwritten in the investment"""
@@ -183,24 +168,61 @@ class OverwriteSus(ProposalSetup, InvestmentSetup, TestCase):
             new_start_date = old_investment.start_date + timedelta(days=5)
             new_end_date = old_investment.end_date + timedelta(days=10)
 
-        sus_to_overwrite = 10
-        InvestmentServices(settings.test_account).modify_investment(investment_id, sus_to_overwrite, start=new_start_date, end=new_end_date)
+        InvestmentServices(settings.test_account).modify_date(investment_id, start=new_start_date, end=new_end_date)
 
         with DBConnection.session() as session:
             new_investment = session.execute(investment_query).scalars().first()
-            self.assertEqual(sus_to_overwrite, new_investment.service_units)
             self.assertEqual(new_start_date, new_investment.start_date)
             self.assertEqual(new_end_date, new_investment.end_date)
 
-    def test_error_on_negative_sus(self) -> None:
-        """Test a ``ValueError`` is raised when assigning negative service units"""
+    def test_error_on_bad_dates(self) -> None:
+        """Test a ``ValueError`` is raised when assigning cronologically wrong start/end dates"""
 
-        account = InvestmentServices(settings.test_account)
+        investment_query = select(Investment).join(Account) \
+             .where(Account.name == settings.test_account) \
+            .order_by(Investment.start_date.desc())
+
+        with DBConnection.session() as session:
+            old_investment = session.execute(investment_query).scalars().first()
+
+            bad_start_date = old_investment.end_date + timedelta(days=1)
+            bad_end_date = old_investment.start_date - timedelta(days=1)
+
+        # No start or end date
         with self.assertRaises(ValueError):
-            account.modify_investment(1, sus=-1)
+            InvestmentServices(settings.test_account).modify_date()
+
+        # Start date after end date
+        with self.assertRaises(ValueError):
+            InvestmentServices(settings.test_account).modify_date(bad_start_date)
+
+        # End date before start date
+        with self.assertRaises(ValueError):
+            InvestmentServices(settings.test_account).modify_date(bad_end_date)
+
+    def test_error_on_bad_dates_with_id(self) -> None:
+        """Test a ``ValueError`` is raised when assigning cronologically wrong start/end dates"""
+
+        investment_query = select(Investment).join(Account) \
+             .where(Account.name == settings.test_account) \
+            .order_by(Investment.start_date.desc())
+
+        with DBConnection.session() as session:
+            investment = session.execute(investment_query).scalars().first()
+            investment_id = investment.id
 
         with self.assertRaises(ValueError):
-            account.modify_investment(1, sus=0)
+            InvestmentServices(settings.test_account).modify_date(investment_id)
+
+        with self.assertRaises(ValueError):
+            InvestmentServices(settings.test_account).modify_date(
+                investment_id,
+                start=investment.end_date + timedelta(days=1))
+
+        with self.assertRaises(ValueError):
+            InvestmentServices(settings.test_account).modify_date(
+                investment_id,
+                end=investment.start_date - timedelta(days=1))
 
 
 class AdvanceInvestmentSus(ProposalSetup, InvestmentSetup, TestCase):
@@ -258,13 +280,13 @@ class MissingInvestmentErrors(ProposalSetup, TestCase):
         """Test for a ``MissingInvestmentError`` error when deleting a missing investment"""
 
         with self.assertRaises(MissingInvestmentError):
-            self.account.delete_investment(inv_id=100)
+            self.account.delete(inv_id=100)
 
-    def test_error_on_modify(self) -> None:
+    def test_error_on_modify_date(self) -> None:
         """Test a ``MissingInvestmentError`` error is raised when modifying a missing investment"""
 
         with self.assertRaises(MissingInvestmentError):
-            self.account.modify_investment(inv_id=100, sus=1)
+            self.account.modify_date(inv_id=100, start = datetime.today())
 
     def test_error_on_add(self) -> None:
         """Test a ``MissingInvestmentError`` error is raised when adding to a missing investment"""

--- a/tests/cli/test_InvestmentParser.py
+++ b/tests/cli/test_InvestmentParser.py
@@ -1,5 +1,6 @@
 """Tests for the ``InvestmentParser`` class"""
 
+from argparse import ArgumentError, ArgumentTypeError
 from datetime import datetime
 from unittest import TestCase, skipIf
 
@@ -26,10 +27,20 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
         # Create an investment, providing only required arguments
         self.assert_parser_matches_func_signature(self.parser, f'create {settings.test_account} --SUs 100')
 
+        # Create an investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(self.parser, f'create {settings.test_account} --SUs -100')
+
         # Create an investment, splitting SUs over multiple repetitions 
         self.assert_parser_matches_func_signature(
             self.parser,
             f'create {settings.test_account} --SUs 100 --num_inv 2')
+
+        # Create an investment, providing a negative num_inv ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --SUs 100 --num_inv -1')
 
         # Create an investment, providing a custom start date
         start_date = datetime.now()
@@ -39,12 +50,24 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
             f'create {settings.test_account} --SUs 100 --start {start_date_str}'
         )
 
+        # Create an investment, providing a custom start date with the wrong format
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --SUs 100 --start 09/01/2500')
+
         # Create an investment, specifying a custom end date
         end_date = start_date + relativedelta(months=6)
         end_date_str = end_date.strftime(settings.date_format)
         self.assert_parser_matches_func_signature(
             self.parser,
             f'create {settings.test_account} --SUs 100 --end {end_date_str}')
+
+        # Create an investment, providing a custom start date with the wrong format
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --SUs 100 --end 09/01/2500')
 
         # Create an investment, specifying a custom start and date
         self.assert_parser_matches_func_signature(
@@ -63,8 +86,20 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
         # Add SUs to the active investment
         self.assert_parser_matches_func_signature(self.parser, f'add_sus {settings.test_account} --SUs 100')
 
+        # Add SUs to the active investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'add_sus {settings.test_account} --SUs -100')
+
         # Add SUs a specific investment
         self.assert_parser_matches_func_signature(self.parser, f'add_sus {settings.test_account} --ID 0 --SUs 100')
+
+        # Add SUs to a specific investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'add_sus {settings.test_account} --ID 0 --SUs -100')
 
     def test_subtract_sus(self) -> None:
         """Test the parsing of arguments by the ``subtract`` command"""
@@ -72,42 +107,84 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
         # Remove SUs from the active investment
         self.assert_parser_matches_func_signature(self.parser, f'subtract_sus {settings.test_account} --SUs 100')
 
+        # Remove SUs from the active investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'subtract_sus {settings.test_account} --SUs -100')
+
         # Remove SUs from a specific investment
         self.assert_parser_matches_func_signature(self.parser, f'subtract_sus {settings.test_account} --ID 0 --SUs 100')
+
+        # Remove SUs from a specific investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'subtract_sus {settings.test_account} --ID 0 --SUs -100')
 
     def test_modify_date(self) -> None:
         """Test the parsing of arguments by the ``modify_date`` command"""
 
-        date = datetime.now().strftime(settings.date_format)
+        start_date = datetime.now()
+        start_date_str = start_date.strftime(settings.date_format)
+        end_date = start_date + relativedelta(months=6)
+        end_date_str = end_date.strftime(settings.date_format)
 
         # Modify the active investment's date, changing only the start date
-        self.assert_parser_matches_func_signature(self.parser, f'modify_date {settings.test_account} --start {date}')
+        self.assert_parser_matches_func_signature(
+            self.parser,
+            f'modify_date {settings.test_account} --start {start_date_str}')
+
+        # Modify the active investment's date, changing only the start date, but with the wrong format
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --start 09/01/2500')
 
         # Modify a specific investment's date, changing only the start date
         self.assert_parser_matches_func_signature(
             self.parser,
-            f'modify_date {settings.test_account} --ID 0 --start {date}'
+            f'modify_date {settings.test_account} --ID 0 --start {start_date_str}'
         )
 
+        # Modify a specific investment's date, changing only the start date, but with the wrong format
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --ID 0 --start 09/01/2500')
+
         # Modify the active investment's date, changing only the end date
-        self.assert_parser_matches_func_signature(self.parser, f'modify_date {settings.test_account} --end {date}')
+        self.assert_parser_matches_func_signature(self.parser, f'modify_date {settings.test_account} --end {end_date_str}')
+
+        # Modify the active investment's date, changing only the end date, but with the wrong format
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --end 09/01/2500')
 
         # Modify a specific investment's date, changing only the end date
         self.assert_parser_matches_func_signature(
             self.parser,
-            f'modify_date {settings.test_account} --ID 0 --start {date}'
+            f'modify_date {settings.test_account} --ID 0 --end {end_date_str}'
         )
+
+        # Modify a specific investment's date, changing only the end date, but with the wrong format
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'create {settings.test_account} --end 09/01/2500')
+
 
         # Modify the active investment's date, changing the start and end dates
         self.assert_parser_matches_func_signature(
             self.parser,
-            f'modify_date {settings.test_account} --start {date} --end {date}'
+            f'modify_date {settings.test_account} --start {start_date_str} --end {end_date_str}'
         )
 
         # Modify a specific investment's date, changing the start and end dates
         self.assert_parser_matches_func_signature(
             self.parser,
-            f'modify_date {settings.test_account} --ID 0 --start {date} --end {date}'
+            f'modify_date {settings.test_account} --ID 0 --start {start_date_str} --end {end_date_str}'
         )
 
     def test_advance_sus(self) -> None:
@@ -116,5 +193,18 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
         # Advance the active investment
         self.assert_parser_matches_func_signature(self.parser, f'advance {settings.test_account} --SUs 100')
 
+        # Advance the active investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'advance {settings.test_account} --SUs -100')
+
         # Advance a specific investment
         self.assert_parser_matches_func_signature(self.parser,f'advance {settings.test_account} --ID 0 --SUs 100')
+
+        # Advance a specific investment, providing a negative SU ammount
+        with self.assertRaises(SystemExit):
+            self.assert_parser_matches_func_signature(
+                self.parser,
+                f'advance {settings.test_account} --ID 0 --SUs -100')
+

--- a/tests/cli/test_InvestmentParser.py
+++ b/tests/cli/test_InvestmentParser.py
@@ -3,6 +3,8 @@
 from datetime import datetime
 from unittest import TestCase, skipIf
 
+from dateutil.relativedelta import relativedelta
+
 from bank import settings
 from bank.cli import InvestmentParser
 from bank.system import Slurm
@@ -25,17 +27,29 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
         self.assert_parser_matches_func_signature(self.parser, f'create {settings.test_account} --SUs 100')
 
         # Create an investment, splitting SUs over multiple repetitions 
-        self.assert_parser_matches_func_signature(self.parser, f'create {settings.test_account} --SUs 100 --repeat 2')
-
-        # Create an investment, providing a custom start date
-        date = datetime.now().strftime(settings.date_format)
         self.assert_parser_matches_func_signature(
             self.parser,
-            f'create {settings.test_account} --SUs 100 --start {date}'
+            f'create {settings.test_account} --SUs 100 --num_inv 2')
+
+        # Create an investment, providing a custom start date
+        start_date = datetime.now()
+        start_date_str = start_date.strftime(settings.date_format)
+        self.assert_parser_matches_func_signature(
+            self.parser,
+            f'create {settings.test_account} --SUs 100 --start {start_date_str}'
         )
 
-        # Create an investment, specifying a custom duration
-        self.assert_parser_matches_func_signature(self.parser, f'create {settings.test_account} --SUs 100 --duration 6')
+        # Create an investment, specifying a custom end date
+        end_date = start_date + relativedelta(months=6)
+        end_date_str = end_date.strftime(settings.date_format)
+        self.assert_parser_matches_func_signature(
+            self.parser,
+            f'create {settings.test_account} --SUs 100 --end {end_date_str}')
+
+        # Create an investment, specifying a custom start and date
+        self.assert_parser_matches_func_signature(
+            self.parser,
+            f'create {settings.test_account} --SUs 100 --start {start_date_str} --end {end_date_str}')
 
     def test_delete_investment(self) -> None:
         """Test the parsing of arguments by the ``delete`` command"""
@@ -59,7 +73,7 @@ class SignatureMatchesCLI(TestCase, CLIAsserts):
         self.assert_parser_matches_func_signature(self.parser, f'subtract_sus {settings.test_account} --SUs 100')
 
         # Remove SUs from a specific investment
-        self.assert_parser_matches_func_signature(self.parser, f'subtract {settings.test_account} --ID 0 --SUs 100')
+        self.assert_parser_matches_func_signature(self.parser, f'subtract_sus {settings.test_account} --ID 0 --SUs 100')
 
     def test_modify_date(self) -> None:
         """Test the parsing of arguments by the ``modify_date`` command"""


### PR DESCRIPTION
Addresses Application Logic Level Items: 

#189 
- Use `start` and `end` instead of `duration`
- Use combination of `datetime.timedelta` and `dateutil.relativedelta` in calculations 
- `num_inv` remains num_invs as multiple investments are being created 

#190
- `delete_investment` -> `delete`
 
#193 
- `inv_id` optional, using active ID as default
- modify_investment -> modify_date, remove access to SUs
- Add validation of dates with existing start/end if only one is provided

#191 and #192
- `inv_id` optional. using active ID as default.

#194 
- use get_active_inv_id 

General
- linting item about logging with f strings.
- line length formatting
- Tests reflect changes to app logic function signatures
