### PR TITLE
Update PackagePublish.yml

### DIFF
--- a/.github/workflows/PackagePublish.yml
+++ b/.github/workflows/PackagePublish.yml
@@ -39,6 +39,8 @@ jobs:
         include:
           - host: https://py00.crc.pitt.edu
             environment: publish-h2p
+          - host: https://upload.pypi.org/legacy/
+            environment: publish-pypi
 
     steps:
       - name: Checkout source


### PR DESCRIPTION
Publish package to PyPi so it can be picked up by the crc-wrappers install.