### PR TITLE
Use settings instead of Slurm.cluster_names for setting up cluster args

### DIFF
--- a/bank/cli/parsers.py
+++ b/bank/cli/parsers.py
@@ -244,8 +244,7 @@ class ProposalParser(BaseParser):
         parser.add_argument('--all-clusters', **su_argument, help='service units awarded across all clusters')
 
         # Add per-cluster arguments for setting service units
-        clusters = settings.clusters or Slurm.cluster_names()        
-        for cluster in clusters:
+        for cluster in settings.clusters:
             parser.add_argument(f'--{cluster}', **su_argument, help=f'service units awarded on the {cluster} cluster')
 
 

--- a/bank/cli/parsers.py
+++ b/bank/cli/parsers.py
@@ -244,6 +244,8 @@ class ProposalParser(BaseParser):
         parser.add_argument('--all-clusters', **su_argument, help='service units awarded across all clusters')
 
         # Add per-cluster arguments for setting service units
+        clusters = settings.clusters or Slurm.cluster_names()        
+
         for cluster in settings.clusters:
             parser.add_argument(f'--{cluster}', **su_argument, help=f'service units awarded on the {cluster} cluster')
 

--- a/bank/cli/parsers.py
+++ b/bank/cli/parsers.py
@@ -245,8 +245,7 @@ class ProposalParser(BaseParser):
 
         # Add per-cluster arguments for setting service units
         clusters = settings.clusters or Slurm.cluster_names()        
-
-        for cluster in settings.clusters:
+        for cluster in clusters:
             parser.add_argument(f'--{cluster}', **su_argument, help=f'service units awarded on the {cluster} cluster')
 
 

--- a/bank/cli/parsers.py
+++ b/bank/cli/parsers.py
@@ -244,7 +244,7 @@ class ProposalParser(BaseParser):
         parser.add_argument('--all-clusters', **su_argument, help='service units awarded across all clusters')
 
         # Add per-cluster arguments for setting service units
-        for cluster in Slurm.cluster_names():
+        for cluster in settings.clusters:
             parser.add_argument(f'--{cluster}', **su_argument, help=f'service units awarded on the {cluster} cluster')
 
 


### PR DESCRIPTION
We removed cluster value validation from ORM, but it's still present in the functions where a cluster is provided, and it was less clear whether or not it should be removed outright. I'm not sure how I missed this in my original round of testing on moss.

```
(bank_deploy) [nlc60@moss bank] fix-cluster-args : crc-bank proposal add_sus test --smp 10000
Traceback (most recent call last):
  File "/ix/crc/nlc60/github/bank/bank_deploy/bin/crc-bank", line 8, in <module>
    sys.exit(CommandLineApplication.execute())
  File "/ix/crc/nlc60/github/bank/bank/cli/app.py", line 46, in execute
    executable(**cli_kwargs)
  File "/ix/crc/nlc60/github/bank/bank/account_logic.py", line 246, in add_sus
    self._verify_cluster_values(**clusters_sus)
  File "/ix/crc/nlc60/github/bank/bank/account_logic.py", line 94, in _verify_cluster_values
    raise ValueError(f'{cluster} is not a valid cluster name.')
ValueError: azure is not a valid cluster name.
```

Current solution is to replace the iterable used to setup the cluster arguments with `settings.clusters` (was `Slurm.cluster_names()`).