### PR TITLE
Fix comparison between date and datetime objects, use and_ instead of between

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -112,6 +112,11 @@ class ProposalServices:
 
         end = end or (start + relativedelta(years=1))
 
+        if isinstance(start, datetime):
+            start = start.date()
+        if isinstance(end, datetime):
+            end = end.date()
+
         with DBConnection.session() as session:
             # Make sure new proposal does not overlap with existing proposals
             overlapping_proposal_sub_1 = select(Account.id) \
@@ -120,11 +125,11 @@ class ProposalServices:
                     .where(Proposal.account_id.in_(overlapping_proposal_sub_1)) \
                     .where(
                            or_(
-                               Proposal.start_date == start.date(),
-                               Proposal.last_active_date == end.date(),
-                               and_(Proposal.start_date >= start.date(), Proposal.start_date <= end.date()),
-                               and_(Proposal.last_active_date >= start.date(), Proposal.last_active_date <= end.date()),
-                               and_(Proposal.start_date < start.date(), Proposal.last_active_date > end.date())
+                               Proposal.start_date == start,
+                               Proposal.last_active_date == end,
+                               and_(Proposal.start_date >= start, Proposal.start_date <= end),
+                               and_(Proposal.last_active_date >= start, Proposal.last_active_date <= end),
+                               and_(Proposal.start_date < start, Proposal.last_active_date > end)
                               )
                           )
 
@@ -203,6 +208,12 @@ class ProposalServices:
                                  f'If providing start or end alone, this comparison is between the provided date and '
                                  f'the proposals\'s existing value')
 
+            if isinstance(start, datetime):
+                start = start.date()
+            if isinstance(end, datetime):
+                end = end.date()
+
+
             last_active_date = end - timedelta(days=1)
 
             # Find any overlapping proposals (not including the proposal being modified)
@@ -212,11 +223,11 @@ class ProposalServices:
                     .where(Proposal.account_id.in_(overlapping_proposal_sub_1)) \
                     .where(
                            or_(
-                               Proposal.start_date == start.date(),
-                               Proposal.last_active_date == end.date(),
-                               and_(Proposal.start_date >= start.date(), Proposal.start_date <= end.date()),
-                               and_(Proposal.last_active_date >= start.date(), Proposal.last_active_date <= end.date()),
-                               and_(Proposal.start_date < start.date(), Proposal.last_active_date > end.date())
+                               Proposal.start_date == start,
+                               Proposal.last_active_date == end,
+                               and_(Proposal.start_date >= start, Proposal.start_date <= end),
+                               and_(Proposal.last_active_date >= start, Proposal.last_active_date <= end),
+                               and_(Proposal.start_date < start, Proposal.last_active_date > end)
                               )
                           )
 

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -125,10 +125,8 @@ class ProposalServices:
                     .where(Proposal.account_id.in_(overlapping_proposal_sub_1)) \
                     .where(
                            or_(
-                               Proposal.start_date == start,
-                               Proposal.last_active_date == end,
-                               not_(and_(start < Proposal.start_date, end < Proposal.start_date)),
-                               not_(and_(start > Proposal.end_date, end  > Proposal.end_date))
+                               not_(and_(start < Proposal.start_date, end <= Proposal.start_date)),
+                               not_(and_(start >= Proposal.end_date, end > Proposal.end_date))
                           )
                     )
 
@@ -212,9 +210,6 @@ class ProposalServices:
             if isinstance(end, datetime):
                 end = end.date()
 
-
-            last_active_date = end - timedelta(days=1)
-
             # Find any overlapping proposals (not including the proposal being modified)
             overlapping_proposal_sub_1 = select(Account.id) \
                                      .where(Account.name == self._account_name)
@@ -222,10 +217,8 @@ class ProposalServices:
                     .where(Proposal.account_id.in_(overlapping_proposal_sub_1)) \
                     .where(
                             or_(
-                               Proposal.start_date == start,
-                               Proposal.last_active_date == end,
-                               not_(and_(start < Proposal.start_date, end < Proposal.start_date)),
-                               not_(and_(start > Proposal.end_date, end  > Proposal.end_date))
+                               not_(and_(start < Proposal.start_date, end  <= Proposal.start_date)),
+                               not_(and_(start >= Proposal.end_date, end  > Proposal.end_date))
                             )
                           )
 

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -124,7 +124,7 @@ class ProposalServices:
             overlapping_proposal_query = select(Proposal) \
                     .where(Proposal.account_id.in_(overlapping_proposal_sub_1)) \
                     .where(
-                           or_(
+                           and_(
                                not_(and_(start < Proposal.start_date, end <= Proposal.start_date)),
                                not_(and_(start >= Proposal.end_date, end > Proposal.end_date))
                           )
@@ -216,7 +216,7 @@ class ProposalServices:
             overlapping_proposal_query = select(Proposal) \
                     .where(Proposal.account_id.in_(overlapping_proposal_sub_1)) \
                     .where(
-                            or_(
+                            and_(
                                not_(and_(start < Proposal.start_date, end  <= Proposal.start_date)),
                                not_(and_(start >= Proposal.end_date, end  > Proposal.end_date))
                             )

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -14,7 +14,7 @@ from typing import Collection, Iterable, Optional, Union
 
 from dateutil.relativedelta import relativedelta
 from prettytable import PrettyTable
-from sqlalchemy import between, delete, and_, or_, select
+from sqlalchemy import delete, and_, or_, select
 
 from . import settings
 from .exceptions import *

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -7,7 +7,7 @@ API Reference
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from logging import getLogger
 from math import ceil
 from typing import Collection, Iterable, Optional, Union

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -7,14 +7,14 @@ API Reference
 
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from logging import getLogger
 from math import ceil
 from typing import Collection, Iterable, Optional, Union
 
 from dateutil.relativedelta import relativedelta
 from prettytable import PrettyTable
-from sqlalchemy import delete, and_, not_, or_, select
+from sqlalchemy import delete, and_, not_, select
 
 from . import settings
 from .exceptions import *

--- a/tests/account_logic/test_ProposalServices.py
+++ b/tests/account_logic/test_ProposalServices.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import date, timedelta
 from unittest import TestCase
 
 from sqlalchemy import join, select
@@ -9,7 +9,7 @@ from bank.account_logic import ProposalServices
 from bank.exceptions import MissingProposalError, ProposalExistsError, AccountNotFoundError
 from bank.orm import Account, Allocation, DBConnection, Proposal
 from tests._utils import account_proposals_query, DAY_AFTER_TOMORROW, DAY_BEFORE_YESTERDAY, EmptyAccountSetup, \
-    ProposalSetup, TODAY, TOMORROW, YESTERDAY
+    ProposalSetup, TOMORROW, YESTERDAY
 
 joined_tables = join(join(Allocation, Proposal), Account)
 sus_query = select(Allocation.service_units_total) \
@@ -212,7 +212,7 @@ class MissingProposalErrors(EmptyAccountSetup, TestCase):
         """Test a ``MissingProposalError`` error is raised when modifying a missing proposal"""
 
         with self.assertRaises(MissingProposalError):
-            self.account.modify_date(**{'start': TODAY, 'proposal_id': 1000})
+            self.account.modify_date(**{'start': date.today(), 'proposal_id': 1000})
 
     def test_error_on_add(self) -> None:
         """Test a ``MissingProposalError`` error is raised when adding to a missing proposal"""
@@ -237,15 +237,15 @@ class PreventOverlappingProposals(EmptyAccountSetup, TestCase):
     def test_neighboring_proposals_are_allowed(self):
         """Test that proposals with neighboring durations are allowed"""
 
-        self.account.create(start=TODAY, end=TODAY+relativedelta(days=1), **{settings.test_cluster: 100})
+        self.account.create(start=date.today(), end=date.today()+relativedelta(days=1), **{settings.test_cluster: 100})
         self.account.create(start=TOMORROW, end=TOMORROW+relativedelta(days=1), **{settings.test_cluster: 100})
 
     def test_error_on_proposal_creation(self):
         """Test new proposals are not allowed to overlap with existing proposals"""
 
-        self.account.create(start=TODAY)
+        self.account.create(start=date.today())
         with self.assertRaises(ProposalExistsError):
-            self.account.create(start=TODAY)
+            self.account.create(start=date.today())
 
     def test_error_on_proposal_creation_default_dates(self):
         """ Test new proposals are not allowed to overlap with existing proposals, using default dates"""

--- a/tests/account_logic/test_ProposalServices.py
+++ b/tests/account_logic/test_ProposalServices.py
@@ -247,6 +247,13 @@ class PreventOverlappingProposals(EmptyAccountSetup, TestCase):
         with self.assertRaises(ProposalExistsError):
             self.account.create(start=TODAY)
 
+    def test_error_on_proposal_creation_default_dates(self):
+        """ Test new proposals are not allowed to overlap with existing proposals, using default dates"""
+
+        self.account.create()
+        with self.assertRaises(ProposalExistsError):
+            self.account.create()
+
     def test_error_on_proposal_modification(self):
         """Test existing proposals can not be modified to overlap with other proposals"""
 

--- a/tests/account_logic/test_ProposalServices.py
+++ b/tests/account_logic/test_ProposalServices.py
@@ -105,8 +105,8 @@ class ModifyDate(ProposalSetup, TestCase):
         with DBConnection.session() as session:
             old_proposal = session.execute(proposal_query).scalars().first()
             proposal_id = old_proposal.id
-            new_start_date = old_proposal.start_date + relativedelta(days=100)
-            new_end_date = old_proposal.end_date + relativedelta(days=100)
+            new_start_date = old_proposal.start_date + relativedelta(years=2)
+            new_end_date = old_proposal.end_date + relativedelta(years=2)
 
         self.account.modify_date(proposal_id, start=new_start_date, end=new_end_date)
 
@@ -237,8 +237,8 @@ class PreventOverlappingProposals(EmptyAccountSetup, TestCase):
     def test_neighboring_proposals_are_allowed(self):
         """Test that proposals with neighboring durations are allowed"""
 
-        self.account.create(start=TODAY, end=TODAY+relativedelta(days=1), **{settings.test_cluster: 100})
-        self.account.create(start=TOMORROW, end=TOMORROW+relativedelta(days=1), **{settings.test_cluster: 100})
+        self.account.create(start=TODAY, end=TOMORROW, **{settings.test_cluster: 100})
+        self.account.create(start=TOMORROW, end=DAY_AFTER_TOMORROW, **{settings.test_cluster: 100})
 
     def test_error_on_proposal_creation_same_start(self):
         """Test new proposals are not allowed to overlap with existing proposals"""
@@ -264,8 +264,8 @@ class PreventOverlappingProposals(EmptyAccountSetup, TestCase):
     def test_error_on_proposal_modification(self):
         """Test existing proposals can not be modified to overlap with other proposals"""
 
-        self.account.create(start=YESTERDAY, end=YESTERDAY+timedelta(days=2), **{settings.test_cluster: 100})
-        self.account.create(start=TOMORROW, end=TOMORROW+timedelta(days=2), **{settings.test_cluster: 100})
+        self.account.create(start=YESTERDAY, end=TOMORROW, **{settings.test_cluster: 100})
+        self.account.create(start=DAY_AFTER_TOMORROW, end=DAY_AFTER_TOMORROW+timedelta(days=2, **{settings.test_cluster: 100})
 
         with self.assertRaises(ProposalExistsError):
             self.account.modify_date(end=DAY_AFTER_TOMORROW)

--- a/tests/account_logic/test_ProposalServices.py
+++ b/tests/account_logic/test_ProposalServices.py
@@ -265,7 +265,7 @@ class PreventOverlappingProposals(EmptyAccountSetup, TestCase):
         """Test existing proposals can not be modified to overlap with other proposals"""
 
         self.account.create(start=YESTERDAY, end=TOMORROW, **{settings.test_cluster: 100})
-        self.account.create(start=DAY_AFTER_TOMORROW, end=DAY_AFTER_TOMORROW+timedelta(days=2, **{settings.test_cluster: 100})
+        self.account.create(start=DAY_AFTER_TOMORROW, end=DAY_AFTER_TOMORROW+timedelta(days=2), **{settings.test_cluster: 100})
 
         with self.assertRaises(ProposalExistsError):
             self.account.modify_date(end=DAY_AFTER_TOMORROW)


### PR DESCRIPTION
See #309 for details, basically the comparison was being done between `datetime.datetime` and `datetime.date` objects, causing it to always return false. The test was specifying a date instead of using the default start/end dates, and therefore never failed. 