### PR TITLE
Deploy fix

### DIFF
--- a/.github/workflows/DocumentationBuild.yml
+++ b/.github/workflows/DocumentationBuild.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Setup environment
         run: /usr/local/bin/entrypoint.sh
 
+      - name: Setup Bank Location
+        run: mkdir -p /ihome/crc/bank 
+
       - name: Checkout project source
         uses: actions/checkout@v3
 

--- a/.github/workflows/PackageTest.yml
+++ b/.github/workflows/PackageTest.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Setup environment
         run: /usr/local/bin/entrypoint.sh
 
+      - name: Create Bank DB Location
+        run: mkdir -p /ihome/crc/bank
+
       - name: Checkout source code
         uses: actions/checkout@v3
 

--- a/.github/workflows/PackageTest.yml
+++ b/.github/workflows/PackageTest.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Setup environment
         run: /usr/local/bin/entrypoint.sh
 
-      - name: Create Bank DB Location
-        run: mkdir -p /ihome/crc/bank
-
       - name: Checkout source code
         uses: actions/checkout@v3
 

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -684,6 +684,7 @@ class AccountServices:
             allocation_total = 0
             floating_su_usage = 0
             floating_su_total = 0
+            floating_su_remaining = 0
 
             for allocation in proposal.allocations:
                 if allocation.cluster_name == 'all_clusters':

--- a/bank/settings.py
+++ b/bank/settings.py
@@ -56,7 +56,7 @@ module:
    >>>
    >>> # The format used by the application to represent dates as strings
    >>> print(settings.date_format)
-   %m/%d/%y
+   %m/%d/%Y
 
 Application settings are cached at import and should not be modified during
 the application runtime. Likewise, modifications to environmental variables
@@ -68,7 +68,7 @@ during execution will not be recognized by the application.
    >>> # does not affect the application settings
    >>> os.environ['BANK_DATE_FORMAT'] = '%m-%d'
    >>> print(settings.date_format)
-   %m/%d/%y
+   %m/%d/%Y
 """
 
 from __future__ import annotations
@@ -84,18 +84,18 @@ test_cluster = 'development'
 nonexistent_account = 'fake_account'
 
 # Define how dates should be displayed as strings (in errors, emails, and STDOUT messages)
-date_format = '%m/%d/%y'
+date_format = '%m/%d/%Y'
 
 # Where and how to write log files
-log_path = _CUR_DIR / 'crc_bank.log'
+log_path = "/ihome/crc/bank/crc_bank.log"
 log_format = '[%(levelname)s] %(asctime)s - %(name)s - %(message)s'
 log_level = 'INFO'
 
 # Path to the application database
-db_path = f"sqlite:///{_CUR_DIR / 'crc_bank.db'}"
+db_path = "sqlite:////ihome/crc/bank/crc_bank.db"
 
 # A list of cluster names to track usage on
-clusters = ('development', 'all_clusters',)
+clusters = ('smp', 'mpi', 'htc', 'gpu', 'teach', 'invest')
 
 # Fraction of service units to carry over when rolling over investments
 # Should be a float between 0 and 1


### PR DESCRIPTION
We need to update the repo setting.py to use the production values for clusters and the db/log location. There are a few other changes to this file around the date format as well.

The item in the account logic was giving an error about the floating_su_total value being referenced before assignment. Not sure how it wasn't caught in my previous testing but it should be included in the deployment.