### PR TITLE
Make sure investment is only being referenced if it exists

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -895,7 +895,7 @@ class AccountServices:
             if not proposal:
                 # Try to cover current raw usage with investment service units
                 total_usage = slurm_acct.get_cluster_usage_total(in_hours=True)
-                if total_usage <= investment_sus:
+                if investment and (total_usage <= investment_sus):
                     LOG.debug(f"Using investment service units to cover usage with no active proposal "
                               f"for {self._account_name}")
                     investment.current_sus -= total_usage


### PR DESCRIPTION
Ran into this while running update status on the newly migrated database:
```
[nlc60@moss bank] deploy_fix : crc-bank admin update_status
Traceback (most recent call last):
  File "/opt/crc/pipx/bin/crc-bank", line 8, in <module>
    sys.exit(CommandLineApplication.execute())
  File "/opt/crc/pipx/opt/venvs/crc-bank/lib64/python3.9/site-packages/bank/cli/app.py", line 46, in execute
    executable(**cli_kwargs)
  File "/opt/crc/pipx/opt/venvs/crc-bank/lib64/python3.9/site-packages/bank/account_logic.py", line 1100, in update_account_status
    account.update_status()
  File "/opt/crc/pipx/opt/venvs/crc-bank/lib64/python3.9/site-packages/bank/account_logic.py", line 901, in update_status
    investment.current_sus -= total_usage
AttributeError: 'NoneType' object has no attribute 'current_sus'
```