### PR TITLE
More descriptive message when active proposal is not found

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -674,13 +674,13 @@ class AccountServices:
             investments = session.execute(self._active_investment_query).scalars().all()
 
             if not proposal:
-                recent_proposals = session.execute(self._recent_proposals_query).scalars().all()
-                if not recent_proposals:
+                recent_proposal = session.execute(self._recent_proposals_query).scalars().first()
+                if not recent_proposal:
                     raise MissingProposalError('This account has never had a proposal')
                 raise MissingProposalError('\nMost recent proposal end date:\n'
-                                           f'    {recent_proposals[0].end_date.strftime(settings.date_format)}\n'
+                                           f'    {recent_proposal.end_date.strftime(settings.date_format)}\n'
                                            'Most recent proposal allocation status:\n'
-                                           f'    {[f"{alloc.cluster_name}:{alloc.service_units_used}/{alloc.service_units_total}" for alloc in recent_proposals[0].allocations]}')
+                                           f'    {[f"{alloc.cluster_name}:{alloc.service_units_used}/{alloc.service_units_total}" for alloc in recent_proposal.allocations]}')
 
             # Proposal End Date as first row
             output_table.add_row(['Proposal End Date:', proposal.end_date.strftime(settings.date_format), ""],

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -677,10 +677,14 @@ class AccountServices:
                 recent_proposal = session.execute(self._recent_proposals_query).scalars().first()
                 if not recent_proposal:
                     raise MissingProposalError('This account has never had a proposal')
+                recent_proposal_end = recent_proposal.end_date.strftime(settings.date_format)
+                recent_proposal_alloc_status = (
+                [f'{alloc.cluster_name}:{alloc.service_units_used}/{alloc.service_units_total}' for alloc in
+                recent_proposal.allocations])
                 raise MissingProposalError('\nMost recent proposal end date:\n'
-                                           f'    {recent_proposal.end_date.strftime(settings.date_format)}\n'
+                                           f'    {recent_proposal_end}\n'
                                            'Most recent proposal allocation status:\n'
-                                           f'    {[f"{alloc.cluster_name}:{alloc.service_units_used}/{alloc.service_units_total}" for alloc in recent_proposal.allocations]}')
+                                           f'    {recent_proposal_alloc_status}')
 
             # Proposal End Date as first row
             output_table.add_row(['Proposal End Date:', proposal.end_date.strftime(settings.date_format), ""],


### PR DESCRIPTION
@fangpingmu Indicated that the message when no active proposal is found does not convey _why_ no active proposal was found:

```
[nlc60@moss bank] descriptive_message_missing_proposal : crc-bank account info mrengasamy
Account mrengasamy has no current proposal
```

This PR add some logic to include the most recent proposal end date and allocation status when no active proposal is found:

```
[nlc60@moss bank] descriptive_message_missing_proposal : crc-bank account info mrengasamy
Account mrengasamy has no active proposal:
Most recent proposal end date:
    08/15/2023
Most recent proposal allocation status:
    ['smp:0/0', 'mpi:0/0', 'gpu:0/0', 'htc:0/100000']
```


