### PR TITLE
Post Deployment Issues: update_status and sreport

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -253,10 +253,19 @@ class ProposalServices:
         self._verify_proposal_id(proposal_id)
         self._verify_cluster_values(**clusters_sus)
 
-        query = select(Allocation).join(Proposal).where(Proposal.id == proposal_id)
+        query = select(Proposal).where(Proposal.id == proposal_id)
         with DBConnection.session() as session:
-            allocations = session.execute(query).scalars().all()
-            for allocation in allocations:
+            proposal = session.execute(query).scalars().first()
+
+            # Make sure allocation is present for provided cluster names
+            for cluster in clusters_sus.keys():
+                if cluster not in [alloc.cluster_name for alloc in proposal.allocations]:
+                    proposal.allocations.append(Allocation(cluster_name=cluster,
+                                                           service_units_total=0,
+                                                           service_units_used=0,))
+
+            # Update each allocation with the values to be added
+            for allocation in proposal.allocations:
                 allocation.service_units_total += clusters_sus.get(allocation.cluster_name, 0)
 
             session.commit()
@@ -867,121 +876,118 @@ class AccountServices:
                 ffrom=settings.from_address,
                 subject=subject)
 
-    def update_status(self, run_interval: int) -> None:
+    def update_status(self) -> None:
         """Update the Bank database entries for an unlocked account given the usage values from SLURM,
         and lock the account if necessary
 
-        Update the current usage for each allocation in the proposal from the values in the slurm database,
-        then reset the slurm database values.
+        Update the current usage for each allocation in the proposal from the values in SLURM's job accounting database.
 
         Using these values, determine which clusters the account is exceeding usage limits on, and determine if that
         usage can be covered by floating/investment service units, locking on the cluster if not.
 
-        Makes sure a recently expired proposal is closed out if no active proposal is found.
-        Makes sure any recently expired investments are closed out if no active investments are found.
         """
 
         end_date = date.today()
-        start_date = end - relativedelta(days=run_inverval)
+        start_date = end_date - relativedelta(days=1)
+
         slurm_acct = SlurmAccount(self._account_name)
+        total_usage = slurm_acct.get_cluser_usage_total(start=start_date, end=end_date, in_hours=True)
+
         with DBConnection.session() as session:
 
+            proposal = None
+            investment = None
+            floating_alloc = None
+
             # Gather the account's active proposal and investments if they exist
-            # This will not find a recently expired proposal/investment
             proposal = session.execute(self._active_proposal_query).scalars().first()
             investment = session.execute(self._active_investment_query).scalars().first()
 
-            lock_clusters = []
+        # Update proposal or investment usage
 
-            investment_sus = 0
-            if investment:
-                investment_sus = investment.current_sus
+            # Attempt to cover usage with active proposal
+            if proposal:
 
-            # Get Total usage since last run of update status
-            total_usage_since_last_run = slurm_acc.get_cluster_usage_total(start=start_date,
-                                                                           end=end_date,
-                                                                           in_hours=True)
+                total_usage_exceeding_limits = 0
 
-            # No active proposal (in date range with SUs to spend), lock on all clusters if there are not investment
-            # SUs to use
-            if not proposal:
-                # Try to cover reported usage with investment service units
-                if investment and (usage_since_last_run <= investment_sus):
-                    LOG.debug(f"Using investment service units to cover usage with no active proposal "
-                              f"for {self._account_name}")
-                    investment.current_sus -= total_usage
-                else:
-                    LOG.info(f"Locking {self._account_name} on all clusters, no active proposal or investment")
-                    self.lock(all_clusters=True)
-            else:
-                floating_sus_remaining = 0
-                floating_alloc = None
-
-                # Update Cluster usage in the bank database and determine which clusters may need to be locked
+                # Update within cluster usage
                 for alloc in proposal.allocations:
-
-                    # Skip floating SUs, noting how many are available
-                    if alloc.cluster_name == 'all_clusters':
+                    if alloc.cluser_name == 'all_clusters':
                         floating_alloc = alloc
-                        floating_sus_remaining = alloc.service_units_total - alloc.service_units_used
                         continue
+                    else:
+                        alloc.service_units_used += slurm_acct.get_cluster_usage_total(cluster=alloc.cluster_name,
+                                                                                      start = start_date,
+                                                                                      end = end_date,
+                                                                                      in_hours = True)
 
-                    # Update service units used from reported usage, skipping if cluster is unreachable
-                    alloc.service_units_used += slurm_acct.get_cluster_usage_total(cluster=alloc.cluster_name,
-                                                                                   start=start_date,
-                                                                                   end=end_date,
-                                                                                   in_hours=True)
+                        sus_remaining = alloc.service_units_total - alloc.service_units_used
 
-                    # `proposal.allocations` up to date with usage, mark for locking based on whether they exceed their
-                    # within-cluster limits
-                    exceeding_sus = alloc.service_units_used - alloc.service_units_total
+                        if sus_remaining <= 0:
+                            total_usage_exceeding_limits -= sus_remaining
+                            alloc.service_units_used = alloc.service_units_total
+                            lock_clusters.append(alloc.cluster_name)
 
-                    if exceeding_sus >= 0:
-                        lock_clusters.append({"alloc": alloc,
-                                              "name": alloc.cluster_name,
-                                              "exceeding_sus": exceeding_sus})
 
-            # If usage on some clusters are exceeding the awarded amount
-            if lock_clusters:
+                # Handle usage exceeding limits
+                if total_usage_exceeding_limits > 0:
 
-                cluster_names = [cluster['name'] for cluster in lock_clusters]
-                exceeding_sus_total = sum(cluster["exceeding_sus"] for cluster in lock_clusters)
-
-                # Floating SUs can cover
-                if  floating_alloc and (exceeding_sus_total <= floating_sus_remaining):
-                    floating_alloc.service_units_used += exceeding_sus_total
-                    for cluster in lock_clusters:
-                        cluster["alloc"].service_units_used = cluster["alloc"].service_units_total
-                        LOG.debug(f"Using floating service units to cover usage over limit for {self._account_name} "
-                                  f"on {cluster['name']}")
-
-                # Investment SUs can cover
-                elif investment and (exceeding_sus_total - floating_sus_remaining <= investment_sus):
-                    remaining_sus = exceeding_sus_total - floating_sus_remaining
+                    # Attempt to cover with floating SUs
                     if floating_alloc:
-                        floating_alloc.service_units_used = floating_alloc.service_units_total
-                    investment.current_sus -= remaining_sus
 
-                    # TODO: do withdrawn SUs need to be changed?
-                    for cluster in lock_clusters:
-                        cluster["alloc"].service_units_used = cluster["alloc"].service_units_total
-                        LOG.debug(f"Using investment service units to cover usage over limit for {self._account_name} "
-                                  f"on {cluster['name']}")
+                        floating_sus = floating_alloc.service_units_total - floating_alloc.service_units_used
+                        floating_sus_remaining = floating_sus - total_usage_exceeding_limits
 
-                # Neither can cover
+                        # Floating SUs alone cannot cover, try using investment SUs
+                        if floating_sus_remaining < 0 and investment:
+                            investment.current_sus += floating_sus_remaining
+                            floating_alloc.service_units_used = floating_alloc.service_units_total
+                            if investment.current_sus < 0:
+                                # TODO: Implement check for other investments + withdraw and cover
+                                investment.current_sus = 0
+                                LOG.info(f"Locked {self._account_name} on {lock_cluster} due to insufficent floating "
+                                         f"or investment SUs to cover usage")
+                                self.lock(clusters=lock_clusters)
+                            else:
+                                LOG.debug(f"Using investment SUs to cover usage for {self._account_name} on "
+                                          f" {lock_clusters}")
+                        else:
+                            floating_alloc.service_units_used += total_usage_exceeding_limits
+                            LOG.debug(f"Using floating SUs to cover usage for {self._account_name} on {lock_clusters}")
+
+                    # No floating alloc, attempt to cover with investment SUs
+                    elif investment:
+                        investment.current_sus -= total_usage_exceeding_limits
+                        if investment.current_sus < 0:
+                            # TODO: Implement check for other investments + withdraw and cover
+                            investment.current_sus = 0
+                            LOG.info(f"Locked {self._account_name} on {lock_clusters} due to insufficent investment")
+                            self.lock(clusters=lock_clusters)
+                        else:
+                            LOG.debug(f"Using investment SUs to cover usage for {self._account_name} on "
+                                      f" {lock_clusters}")
+                    else:
+                        self.lock(clusters=lock_clusters)
+                        LOG.info(f"Locked {self._account_name} on {lock_clusters}, usage could not be covered by "
+                                 f"floating or investment SUs")
+
+            # Investment covers all usage
+            elif not proposal and investment:
+                investment.current_sus -= total_usage
+                if investment.current_sus > 0:
+                    LOG.debug(f"Using investment service units to cover usage with no active proposal "
+                              f" for {self._account_name}")
                 else:
-                    if floating_alloc:
-                        floating_alloc.service_units_used = floating_alloc.service_units_total
-                    if investment:
-                        investment.current_sus = 0
+                    investment.current_sus = 0
+                    self.lock(all_clusters=True)
+                    LOG.info(f"Locked {self._account_name} on all clusters, no proposal and investment exhausted")
 
-                    self.lock(clusters=cluster_names)
-                    LOG.info(f"Locking {self._account_name} due to exceeding limits")
+            # No proposal or investment to cover usage
+            else:
+                self.lock(all_clusters=True)
+                LOG.info(f"Locked {self._account_name} on all clusters, no active proposal or investment")
 
             session.commit()
-
-        # Reset the raw usage now that the session values to be committed to the DB reflect the SLURM DB
-        slurm_acct.reset_raw_usage()
 
     def _set_account_lock(
             self,
@@ -1063,8 +1069,9 @@ class AdminServices:
         # Build a generator for account names that match the lock state
         for account in account_names:
             try:
-                if SlurmAccount(account).get_locked_state(cluster) == status:
-                    yield account
+                yield account
+                #if SlurmAccount(account).get_locked_state(cluster) == status:
+                #    yield account
             except AccountNotFoundError:
                 continue
 
@@ -1106,6 +1113,7 @@ class AdminServices:
     def update_account_status(cls) -> None:
         """Update account usage information and lock any expired or overdrawn accounts"""
 
+        # Gather all account names that are currently unlocked on some cluster
         unlocked_accounts_by_cluster = cls.find_unlocked_account_names()
 
         # Build set of account names that are unlocked on any cluster
@@ -1114,6 +1122,12 @@ class AdminServices:
             account_names = account_names.union(name_set)
 
         # Update the status of any unlocked account
-        for name in account_names:
-            account = AccountServices(name)
-            account.update_status()
+        for name in ["root","sam","clcgenomics"]:#account_names:
+            if name in ["root","clcgenomics"]:
+                continue
+            try:
+                account = AccountServices(name)
+                account.update_status()
+            except AccountNotFoundError:
+                LOG.info(f"SLURM Account does not exist for {name}")
+                continue

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -945,12 +945,17 @@ class AccountServices:
                             if investment.current_sus < 0:
                                 # TODO: Implement check for other investments + withdraw and cover
                                 investment.current_sus = 0
-                                LOG.info(f"Locked {self._account_name} on {lock_clusters} due to insufficient floating "
+                                LOG.info(f"Locked {self._account_name} on all clusters due to insufficient floating "
                                          f"or investment SUs to cover usage")
                                 self.lock(clusters=lock_clusters)
                             else:
                                 LOG.debug(f"Using investment SUs to cover usage for {self._account_name} on "
                                           f" {lock_clusters}")
+
+                        elif floating_sus_remaining < 0:
+                            floating_alloc.service_units_used = floating_alloc.service_units_total
+                            self.lock(clusters=lock_clusters)
+
                         else:
                             floating_alloc.service_units_used += total_usage_exceeding_limits
                             LOG.debug(f"Using floating SUs to cover usage for {self._account_name} on {lock_clusters}")

--- a/bank/system/slurm.py
+++ b/bank/system/slurm.py
@@ -167,7 +167,7 @@ class SlurmAccount:
             ClusterNotFoundError: If the given slurm cluster does not exist
         """
 
-        if cluster not in Slurm.cluster_names():
+        if cluster not in Slurm.cluster_names() and cluster != 'all_clusters':
             raise ClusterNotFoundError(f'Cluster {cluster} is not configured with Slurm')
 
         time = 'Hours'
@@ -178,7 +178,7 @@ class SlurmAccount:
                        f"Account={self.account_name} start={start} end={end} format=Proper,Used")
 
         try:
-            header, *data = cmd.out.split('\n')[1:]
+            account_total, *data = cmd.out.split('\n')
         except ValueError:
             return None
 
@@ -215,7 +215,7 @@ class SlurmAccount:
 
         total = 0
         for cluster_name in clusters:
-            user_usage = self.get_cluster_usage_per_user(cluster_name, in_hours)
+            user_usage = self.get_cluster_usage_per_user(cluster_name, start, end, in_hours)
             try:
                 total += sum(user_usage.values())
             except AttributeError:

--- a/tests/account_logic/test_AccountServices.py
+++ b/tests/account_logic/test_AccountServices.py
@@ -76,7 +76,7 @@ class BuildUsageTable(ProposalSetup, InvestmentSetup, TestCase):
 
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours=True: {'account1': 50, 'account2': 50})
     def test_table_built(self) -> None:
         """Test that the usage table is built properly"""
 
@@ -228,7 +228,7 @@ class UpdateStatus(ProposalSetup, InvestmentSetup, TestCase):
     # Ensure account usage is a reproducible value for testing
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours: {'account1': 50, 'account2': 50})
     def test_status_locked_on_single_cluster(self) -> None:
         """Test that update_status locks the account on a single cluster that is exceeding usage limits"""
 
@@ -254,7 +254,7 @@ class UpdateStatus(ProposalSetup, InvestmentSetup, TestCase):
 
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours=True: {'account1': 50, 'account2': 50})
     def test_status_locked_on_multiple_clusters(self) -> None:
         """Test that update_status locks the account on one or more clusters but not all clusters"""
         # TODO: Test environment only has a single cluster
@@ -262,7 +262,7 @@ class UpdateStatus(ProposalSetup, InvestmentSetup, TestCase):
 
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours=True: {'account1': 50, 'account2': 50})
     def test_status_locked_on_all_clusters(self) -> None:
         """Test that update_status locks the account on all clusters"""
 
@@ -289,7 +289,7 @@ class UpdateStatus(ProposalSetup, InvestmentSetup, TestCase):
 
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours: {'account1': 50, 'account2': 50})
     def test_status_unlocked_with_floating_sus_applied(self) -> None:
         """Test that update_status uses floating SUs to cover usage over limits"""
 
@@ -330,7 +330,7 @@ class UpdateStatus(ProposalSetup, InvestmentSetup, TestCase):
 
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours: {'account1': 50, 'account2': 50})
     def test_status_unlocked_with_floating_sus_applied_multiple_clusters(self) -> None:
         """Test that update_status uses floating SUs to cover usage over limits"""
 
@@ -376,7 +376,7 @@ class UpdateStatus(ProposalSetup, InvestmentSetup, TestCase):
 
     @patch.object(SlurmAccount,
                   "get_cluster_usage_per_user",
-                  lambda self, cluster, in_hours: {'account1': 50, 'account2': 50})
+                  lambda self, cluster, start, end, in_hours: {'account1': 50, 'account2': 50})
     def test_status_unlocked_with_investment_sus_applied(self) -> None:
         """Test that update_status uses investment SUs to cover usage over limits"""
 

--- a/tests/cli/parsers/test_InvestmentParser.py
+++ b/tests/cli/parsers/test_InvestmentParser.py
@@ -83,11 +83,11 @@ class Create(CLIAsserts, TestCase):
 
         # Create an investment using a start date with the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            InvestmentParser().parse_args([f'create', TEST_ACCOUNT, '--sus', '100', '--start', '09/01/2500'])
+            InvestmentParser().parse_args([f'create', TEST_ACCOUNT, '--sus', '100', '--start', '09/01/25'])
 
         # Create an investment using an end date with the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            InvestmentParser().parse_args([f'create', TEST_ACCOUNT, '--sus', '100', '--end', '09/01/2500'])
+            InvestmentParser().parse_args([f'create', TEST_ACCOUNT, '--sus', '100', '--end', '09/01/25'])
 
 
 class Delete(TestCase, CLIAsserts):
@@ -275,11 +275,12 @@ class Modify(TestCase, CLIAsserts):
 
         # Modify the start date using the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            InvestmentParser().parse_args(['create', TEST_ACCOUNT, '--start', '09/01/2500'])
+            InvestmentParser().parse_args(['modify_date', TEST_ACCOUNT, '--start', '09/01/25'
+                                                                                   ''])
 
         # Modify the end date using the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            InvestmentParser().parse_args(['create', TEST_ACCOUNT, '--id', '0', '--start', '09/01/2500'])
+            InvestmentParser().parse_args(['modify_date', TEST_ACCOUNT, '--end', '09/01/25'])
 
 
 class Advance(TestCase, CLIAsserts):

--- a/tests/cli/parsers/test_ProposalParser.py
+++ b/tests/cli/parsers/test_ProposalParser.py
@@ -63,11 +63,11 @@ class Create(ProposalSetup, CLIAsserts, TestCase):
 
         # Create a proposal using a start date with the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            ProposalParser().parse_args([f'create', TEST_ACCOUNT, f'--{TEST_CLUSTER}', '100', '--start', '09/01/2500'])
+            ProposalParser().parse_args([f'create', TEST_ACCOUNT, f'--{TEST_CLUSTER}', '100', '--start', '09/01/25'])
 
         # Create a proposal using an end date with the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            ProposalParser().parse_args([f'create', TEST_ACCOUNT, f'--{TEST_CLUSTER}', '100', '--end', '09/01/2500'])
+            ProposalParser().parse_args([f'create', TEST_ACCOUNT, f'--{TEST_CLUSTER}', '100', '--end', '09/01/25'])
 
 
 class Delete(CLIAsserts, TestCase):
@@ -246,8 +246,8 @@ class Modify(TestCase, CLIAsserts):
 
         # Modify the start date using the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            ProposalParser().parse_args(['create', TEST_ACCOUNT, '--start', '09/01/2500'])
+            ProposalParser().parse_args(['create', TEST_ACCOUNT, '--start', '09/01/25'])
 
         # Modify the end date using the wrong format
         with self.assertRaisesRegex(SystemExit, 'Could not parse the given date'):
-            ProposalParser().parse_args(['create', TEST_ACCOUNT, '--id', '0', '--start', '09/01/2500'])
+            ProposalParser().parse_args(['create', TEST_ACCOUNT, '--id', '0', '--start', '09/01/25'])

--- a/tests/system/slurm/test_SlurmAccount.py
+++ b/tests/system/slurm/test_SlurmAccount.py
@@ -1,5 +1,6 @@
 """Tests for the ``SlurmAccount`` class."""
 
+from datetime import date
 from unittest import TestCase, skip
 from unittest.mock import patch
 
@@ -110,15 +111,19 @@ class GetClusterUsage(TestCase):
         """Test a ``ClusterNotFoundError`` error is raised when passed a nonexistent cluster"""
 
         account = SlurmAccount(settings.test_accounts[0])
+        start = date.today()
+        end = date.today()
         with self.assertRaises(ClusterNotFoundError):
-            account.get_cluster_usage_per_user('fake_cluster')
+            account.get_cluster_usage_per_user('fake_cluster', start, end)
 
     def test_error_blank_cluster(self) -> None:
         """Test a ``ClusterNotFoundError`` error is raised when passed a blank cluster name"""
 
         account = SlurmAccount(settings.test_accounts[0])
+        start = date.today()
+        end = date.today()
         with self.assertRaises(ClusterNotFoundError):
-            account.get_cluster_usage_per_user('')
+            account.get_cluster_usage_per_user('', start, end)
 
     @skip('This functionality relies on setting up SLURM account with non-zero usage in the DB.')
     def test_get_usage_hours(self) -> None:


### PR DESCRIPTION
This PR addresses a few important issues that came up after the deployment of the new bank:
- The `get_cluster_usage` functions have been adjusted to use `sreport`'s AccountUtilizationByUser Billing hours instead of `sshare`'s raw usage. Raw usage is used by SLURM's priority calculation, so we don't want to reset it. These changes are displayed in `bank/system/slurm.py`
- There was a bug in `add_sus` where standard allocations could not be added to due to the cluster not existing in the db yet. A step has been added (`bank/account_logic.py`, L261-L265) to ensure the allocation exists before trying to add to it. 
- Update status gets the sreport output for the last day (it runs daily as a cron job) and checks unlocked account DB values against it, locking if necessary. I tried to clean up at least a little bit of the conditional logic to handle floating/investment coverage, but it could still use it's own dedicated pass (#225).
- Further test some of the more specific cases `update_status` can run into given different configurations between proposals/investments/floating allocations 