### PR TITLE
`--force` option for proposal changes

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -140,10 +140,11 @@ class ProposalServices:
                 if force:
                     warn("Creating the proposal despite overlap with an existing proposal")
                 else:
-                    raise ProposalExistsError(f'Proposals for a given account cannot overlap: \n'
+                    raise ProposalExistsError(f'By default, proposals for a given account cannot overlap: \n'
                                               f'    existing range {overlapping_proposal.start_date} '
                                               f'- {overlapping_proposal.end_date} \n'
-                                              f'    provided range {start} - {end}')
+                                              f'    provided range {start} - {end} \n'
+                                              f'This can be overridden with the `--force` flag')
 
             # Create the new proposal and allocations
             new_proposal = Proposal(
@@ -242,10 +243,11 @@ class ProposalServices:
                 if force:
                     warn("Modifying the proposal dates despite overlap with an existing proposal")
                 else:
-                    raise ProposalExistsError(f'Proposals for a given account cannot overlap: \n'
+                    raise ProposalExistsError(f'By default, proposals for a given account cannot overlap: \n'
                                               f'    existing range {overlapping_proposal.start_date} '
                                               f'- {overlapping_proposal.end_date} \n'
-                                              f'    provided range {start} - {end}')
+                                              f'    provided range {start} - {end} \n'
+                                              f'This can be overridden with the `--force` flag')
 
             # Update the proposal record
             if start != proposal.start_date:

--- a/bank/cli/parsers.py
+++ b/bank/cli/parsers.py
@@ -2,9 +2,8 @@
 application's commandline interface. Individual parsers are designed around
 different services provided by the banking app.
 """
-
 import sys
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser, BooleanOptionalAction, Namespace
 from datetime import datetime
 from typing import List, Tuple
 
@@ -192,9 +191,7 @@ class ProposalParser(BaseParser):
             help=f'proposal end date ({safe_date_format}) - defaults to 1 year from today')
         create_parser.add_argument(
             '--force',
-            metavar='force',
-            type=bool,
-            default=False,
+            action=BooleanOptionalAction,
             help=f"boolean flag for whether or not to set the existing proposal to inactive and substitute a proposal "
                  f"with the provided values in it's place - default is False"
         )
@@ -241,9 +238,7 @@ class ProposalParser(BaseParser):
             help=f'set a new proposal end date ({safe_date_format})')
         modify_date_parser.add_argument(
             '--force',
-            metavar='force',
-            type=bool,
-            default=False,
+            action=BooleanOptionalAction,
             help=f"boolean flag for whether or not to overwrite the existing proposal's dates, even if it "
                  f"would otherwise cause date range overlap - default is False"
         )

--- a/bank/cli/parsers.py
+++ b/bank/cli/parsers.py
@@ -190,6 +190,14 @@ class ProposalParser(BaseParser):
             metavar='date',
             type=Date,
             help=f'proposal end date ({safe_date_format}) - defaults to 1 year from today')
+        create_parser.add_argument(
+            '--force',
+            metavar='force',
+            type=bool,
+            default=False,
+            help=f"boolean flag for whether or not to set the existing proposal to inactive and substitute a proposal "
+                 f"with the provided values in it's place - default is False"
+        )
         self._add_cluster_args(create_parser)
 
         # Proposal deletion
@@ -231,6 +239,14 @@ class ProposalParser(BaseParser):
             metavar='date',
             type=Date,
             help=f'set a new proposal end date ({safe_date_format})')
+        modify_date_parser.add_argument(
+            '--force',
+            metavar='force',
+            type=bool,
+            default=False,
+            help=f"boolean flag for whether or not to overwrite the existing proposal's dates, even if it "
+                 f"would otherwise cause date range overlap - default is False"
+        )
 
     @staticmethod
     def _add_cluster_args(parser: ArgumentParser) -> None:
@@ -344,6 +360,7 @@ class InvestmentParser(BaseParser):
             type=Date,
             help=f'set a new investment end date ({safe_date_format})')
 
+        # Advance investment SUs
         advance_parser = subparsers.add_parser(
             name='advance',
             help='forward service units from future investments to a given investment')

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -26,11 +26,13 @@ account_investment_ids_query = select(Investment.id) \
 
 active_proposal_query = select(Proposal) \
                         .where(Proposal.account_id.in_(account_subquery)) \
-                        .where(Proposal.is_active)
+                        .where(Proposal.is_active) \
+                        .order_by(Proposal.start_date.desc())
 
 active_investment_query = select(Investment) \
                         .where(Investment.account_id.in_(account_subquery)) \
-                        .where(Investment.is_active)
+                        .where(Investment.is_active) \
+                        .order_by(Investment.start_date.desc())
 
 
 def add_proposal_to_test_account(proposal: Proposal) -> None:

--- a/tests/cli/parsers/test_ProposalParser.py
+++ b/tests/cli/parsers/test_ProposalParser.py
@@ -20,6 +20,12 @@ class Create(ProposalSetup, CLIAsserts, TestCase):
 
         self.assert_parser_matches_func_signature(ProposalParser(), f'create {TEST_ACCOUNT} --{TEST_CLUSTER} 100')
 
+    def test_create_proposal_force(self) -> None:
+        """Test proposal creation providing the force argument"""
+
+        self.assert_parser_matches_func_signature(ProposalParser(),
+                                                  f'create {TEST_ACCOUNT} --{TEST_CLUSTER} 100 --force')
+
     def test_missing_account_name_error(self) -> None:
         """Test a ``SystemExit`` error is raised for a missing ``account`` argument"""
 
@@ -212,6 +218,11 @@ class Modify(TestCase, CLIAsserts):
         # Modify the start and end dates
         self.assert_parser_matches_func_signature(
             ProposalParser(), f'modify_date {TEST_ACCOUNT} --start {self.start_date_str} --end {self.end_date_str}')
+
+        # Modify the start and end dates, forcing
+        self.assert_parser_matches_func_signature(
+            ProposalParser(),
+            f'modify_date {TEST_ACCOUNT} --start {self.start_date_str} --end {self.end_date_str} --force')
 
     def test_modify_specific_proposal(self) -> None:
         """Test changing the dates while specifying a proposal ID"""


### PR DESCRIPTION
This PR implements a "--force" option for both proposal creation and proposal date modification commands that are otherwise blocked due to overlapping date range with an extant proposal.
A warning is shown when these options are used. The default behavior is `force=False` when the flag is not supplied, and `--no-force` can be explicitly supplied. 

There are valid cases where users want to renew their SLURM allocation to be renewed prior to it's end date, and these changes will make that possible again.

If the active proposal/investment queries to the database return multiple proposals, the entries are sorted by descending start date, and the first is chosen. This should not cause any problems with proposals/investments with future start dates, as they do not register as active. 