### PR TITLE
Do not skip zero usage clusters if they have an award

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -709,28 +709,38 @@ class AccountServices:
             floating_su_remaining = 0
 
             for allocation in proposal.allocations:
+
+                # Skip any cluster that does not have service units awarded on it
+                if not allocation.service_units_total:
+                    continue
+
+                cluster_name = str.upper(allocation.cluster_name)
+
+                # Determine whether or not there is a floating allocation
                 if allocation.cluster_name == 'all_clusters':
                     floating_su_usage = allocation.service_units_used
                     floating_su_total = allocation.service_units_total
                     floating_su_remaining = floating_su_total - floating_su_usage
                     continue
 
+                # Gather usage data from sreport
                 usage_data = slurm_acct.get_cluster_usage_per_user(cluster=allocation.cluster_name,
                                                                    start=proposal.start_date,
                                                                    end=proposal.end_date,
                                                                    in_hours=True)
 
-                # Skip if usage data is empty on the cluster
+                
+
+                # Skip displaying usage data if there is none, just show cluster total
                 if not usage_data:
+                    output_table.add_row([f"Cluster: {cluster_name}",
+                                          f"Total SUs: {allocation.service_units_total}",""], divider=True)
+                    output_table.add_row(["", "", ""], divider=True)
                     continue
 
                 total_usage_on_cluster = sum(usage_data.values())
                 total_cluster_percent = self._calculate_percentage(total_usage_on_cluster,
                                                                    allocation.service_units_total)
-                cluster_name = str.upper(allocation.cluster_name)
-                if not allocation.service_units_total:
-                    continue
-
                 output_table.add_row([f"Cluster: {cluster_name}",
                                      f"Total SUs: {allocation.service_units_total}",""], divider=True)
 


### PR DESCRIPTION
`build_usage_table` was skipping the display of allocations that did not yet have any usage, despite having an amount awarded. 

I've updated the code to display them so they appear in `crc-usage` (See the MPI cluster below):

```
(bank_deploy) [root@moss bank]# crc-bank account info jmendoza-arenas
+----------------------------+----------------------------+----------------+
|     Proposal End Date:     |         08/06/2024         |                |
+----------------------------+----------------------------+----------------+
|        Proposal ID:        |            930             |                |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Cluster: MPI        |     Total SUs: 2800000     |                |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Cluster: HTC        |     Total SUs: 130000      |                |
+----------------------------+----------------------------+----------------+
|            User            |          SUs Used          |     % Used     |
+----------------------------+----------------------------+----------------+
|           jum151           |           13413            |       10       |
+----------------------------+----------------------------+----------------+
|      Overall for HTC       |           13413            |       10       |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Floating SUs        |       SUs Remaining        |     % Used     |
+----------------------------+----------------------------+----------------+
|       *Floating SUs        |                            |                |
|       are applied on       |                            |                |
|       any cluster to       |           25000*           |       0        |
|     cover usage above      |                            |                |
|         Total SUs          |                            |                |
+----------------------------+----------------------------+----------------+
|      Aggregate Usage       |             10             |                |
+----------------------------+----------------------------+----------------+
```