### PR TITLE
Rework Update Status to use all sources of surplus SUs to cover usage

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -904,8 +904,9 @@ class AccountServices:
 
         """
 
-        end_date = date.today()
-        start_date = end_date - relativedelta(days=1)
+        # Update status runs daily
+        start_date = date.today()
+        end_date = start_date + relativedelta(days=1)
 
         slurm_acct = SlurmAccount(self._account_name)
         total_usage = slurm_acct.get_cluster_usage_total(start=start_date, end=end_date, in_hours=True)

--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -732,10 +732,10 @@ class AccountServices:
                     continue
 
                 output_table.add_row([f"Cluster: {cluster_name}",
-                                     f"Available SUs: {allocation.service_units_total}",""], divider=True)
+                                     f"Total SUs: {allocation.service_units_total}",""], divider=True)
 
                 # Build a list of individual user usage on the current cluster
-                output_table.add_row(["User", "SUs Used", "Percentage of Total"], divider=True)
+                output_table.add_row(["User", "SUs Used", "% Used"], divider=True)
                 for index, data in enumerate(usage_data.items()):
                     user = data[0]
                     user_usage = data[1]
@@ -757,11 +757,12 @@ class AccountServices:
             usage_percentage = self._calculate_percentage(aggregate_usage_total, allocation_total)
 
             floating_su_percent = self._calculate_percentage(floating_su_usage, floating_su_total)
-            output_table.add_row(['Floating Service Units', "Units Remaining", "Percent Used"], divider=True)
-            output_table.add_row([f'**Floating SUs are applied to any cluster to cover usage ',
-                                  floating_su_remaining,
-                                  floating_su_percent])
-            output_table.add_row([f'exceeding proposal limits', "", ""], divider=True)
+            output_table.add_row(['Floating SUs', "SUs Remaining", "% Used"], divider=True)
+            output_table.add_row([f'*Floating SUs', "", ""])
+            output_table.add_row([f'are applied on', "", ""])
+            output_table.add_row([f'any cluster to', str(floating_su_remaining)+'*', floating_su_percent])
+            output_table.add_row([f'cover usage above', "", ""])
+            output_table.add_row([f'Total SUs', "", ""], divider=True)
 
             # Add another inner table describing aggregate usage
             if not investments:
@@ -771,11 +772,14 @@ class AccountServices:
                 investment_percentage = self._calculate_percentage(aggregate_usage_total,
                                                                    allocation_total + investment_total)
 
-                output_table.add_row(['Investments Total', str(investment_total)+f"\N{ASTERISK}", ""])
-                output_table.add_row(['Aggregate Usage (excluding investments)', usage_percentage, ""])
-                output_table.add_row(['Aggregate Usage', investment_percentage, ""])
-                output_table.add_row([f'\N{ASTERISK}Investment SUs are applied to cover usage ', "",""], divider=True)
-                output_table.add_row([f'exceeding proposal limits across any cluster',"",""])
+                output_table.add_row(['Investment SUs', "SUs Remaining", "% Used"], divider=True)
+                output_table.add_row([f'**Investment SUs', "",""])
+                output_table.add_row([f'are applied on', "", ""])
+                output_table.add_row([f'any cluster to', str(investment_total)+"**", investment_percentage])
+                output_table.add_row([f'cover usage above',"",""])
+                output_table.add_row([f'Total SUs', "", ""], divider=True)
+                output_table.add_row(['Aggregate Usage', usage_percentage, ""])
+                output_table.add_row(['(no investments)', "", ""])
 
             return output_table
 

--- a/bank/system/slurm.py
+++ b/bank/system/slurm.py
@@ -175,7 +175,7 @@ class SlurmAccount:
             time = 'Seconds'
 
         cmd = ShellCmd(f"sreport cluster AccountUtilizationByUser -Pn -T Billing -t {time} cluster={cluster} "
-                       f"Account={self.account_name} start={start} end={end} format=Proper,Used")
+                       f"Account={self.account_name} start={start.strftime('%Y-%m-%d')} end={end.strftime('%Y-%m-%d')} format=Proper,Used")
 
         try:
             account_total, *data = cmd.out.split('\n')

--- a/tests/_utils.py
+++ b/tests/_utils.py
@@ -124,6 +124,7 @@ class InvestmentSetup(EmptyAccountSetup):
         """Ensure there exists a user investment for the test user account"""
 
         super().setUp()
+
         investments = []
         for i in range(3):
             start = TODAY + ((i - 1) * timedelta(days=365))
@@ -137,10 +138,5 @@ class InvestmentSetup(EmptyAccountSetup):
                 withdrawn_sus=0,
                 rollover_sus=0
             )
-            investments.append(inv)
 
-        with DBConnection.session() as session:
-            result = session.execute(select(Account).where(Account.name == settings.test_accounts[0]))
-            account = result.scalars().first()
-            account.investments.extend(investments)
-            session.commit()
+            add_investment_to_test_account(inv)


### PR DESCRIPTION
Previously, update status would only use the first disbursement of a single active investment. Now it will utilize all service units in an investment if need be, and it will utilize multiple investments.

This PR also makes sure that the current date and the correct format are being passed in to sreport