### PR TITLE
Include zero usage users in crc-bank account info output

### DIFF
--- a/bank/system/slurm.py
+++ b/bank/system/slurm.py
@@ -174,11 +174,14 @@ class SlurmAccount:
         if not in_hours:
             time = 'Seconds'
 
-        cmd = ShellCmd(f"sreport cluster AccountUtilizationByUser -Pn -T Billing -t {time} cluster={cluster} "
+        cmd1 = ShellCmd(f"sreport cluster AccountUtilizationByUser -Pn -T Billing -t {time} cluster={cluster} "
                        f"Account={self.account_name} start={start.strftime('%Y-%m-%d')} end={end.strftime('%Y-%m-%d')} format=Proper,Used")
 
+        cmd2 = ShellCmd(f"sacctmgr -nP show association where Account={self.account_name} Cluster={cluster} Format=User")
+
         try:
-            account_total, *data = cmd.out.split('\n')
+            account_total, *data = cmd1.out.split('\n')
+            users = cmd2.out.split('\n')
         except ValueError:
             return None
 
@@ -187,6 +190,12 @@ class SlurmAccount:
             user, usage = line.split('|')
             usage = int(usage)
             out_data[user] = usage
+
+        for user in users:
+            if user in out_data.keys():
+                continue
+            else:
+                out_data[user] = 0
 
         return out_data
 


### PR DESCRIPTION
#334 requests for `crc-bank account info` to display the whole list of users on the allocation like how it was in the previous iteration of the bank. While there is not a great way to display this if the account only has a standard allocation in it's proposal, I used `sacctmgr` and the output from `sreport` to build the full list:

```
(bank_deploy) [nlc60@moss bank] all-users-crc-usage : crc-bank account info sam
+----------------------------+---------------------------+----------------+
|     Proposal End Date:     |         04/26/2024        |                |
+----------------------------+---------------------------+----------------+
|        Proposal ID:        |             20            |                |
+----------------------------+---------------------------+----------------+
|                            |                           |                |
+----------------------------+---------------------------+----------------+
|        Cluster: SMP        |     Total SUs: 100000     |                |
+----------------------------+---------------------------+----------------+
|            User            |          SUs Used         |     % Used     |
+----------------------------+---------------------------+----------------+
|           chx33            |            225            |      N/A       |
|           djp81            |             0             |      N/A       |
|          fangping          |             4             |      N/A       |
|          kimwong           |             35            |      N/A       |
|           leb140           |             96            |      N/A       |
|           nlc60            |             0             |      N/A       |
|           yak73            |            150            |      N/A       |
|          bmooreii          |             0             |      N/A       |
|            fis7            |             0             |      N/A       |
|          gnowmik           |             0             |      N/A       |
|            jar7            |             0             |      N/A       |
|           ketan            |             0             |      N/A       |
|           mak189           |             0             |      N/A       |
|           sak236           |             0             |      N/A       |
|           shs159           |             0             |      N/A       |
+----------------------------+---------------------------+----------------+
|      Overall for SMP       |            510            |       0        |
+----------------------------+---------------------------+----------------+
|                            |                           |                |
+----------------------------+---------------------------+----------------+
|        Cluster: MPI        |     Total SUs: 100000     |                |
+----------------------------+---------------------------+----------------+
|            User            |          SUs Used         |     % Used     |
+----------------------------+---------------------------+----------------+
|           chx33            |            1132           |       1        |
|          kimwong           |             55            |      N/A       |
|           leb140           |            5035           |       5        |
|           nlc60            |             20            |      N/A       |
|          bmooreii          |             0             |      N/A       |
|           djp81            |             0             |      N/A       |
|          fangping          |             0             |      N/A       |
|            fis7            |             0             |      N/A       |
|          gnowmik           |             0             |      N/A       |
|            jar7            |             0             |      N/A       |
|           ketan            |             0             |      N/A       |
|           mak189           |             0             |      N/A       |
|           sak236           |             0             |      N/A       |
|           shs159           |             0             |      N/A       |
|           yak73            |             0             |      N/A       |
+----------------------------+---------------------------+----------------+
|      Overall for MPI       |            6242           |       6        |
+----------------------------+---------------------------+----------------+
|                            |                           |                |
+----------------------------+---------------------------+----------------+
|        Cluster: GPU        |     Total SUs: 100000     |                |
+----------------------------+---------------------------+----------------+
|            User            |          SUs Used         |     % Used     |
+----------------------------+---------------------------+----------------+
|           chx33            |             40            |      N/A       |
|          fangping          |             15            |      N/A       |
|          gnowmik           |             0             |      N/A       |
|          kimwong           |            121            |      N/A       |
|           leb140           |            1385           |       1        |
|           nlc60            |             2             |      N/A       |
|           yak73            |            3864           |       3        |
|          bmooreii          |             0             |      N/A       |
|           djp81            |             0             |      N/A       |
|            fis7            |             0             |      N/A       |
|            jar7            |             0             |      N/A       |
|           ketan            |             0             |      N/A       |
|           mak189           |             0             |      N/A       |
|           sak236           |             0             |      N/A       |
|           shs159           |             0             |      N/A       |
+----------------------------+---------------------------+----------------+
|      Overall for GPU       |            5427           |       5        |
+----------------------------+---------------------------+----------------+
|                            |                           |                |
+----------------------------+---------------------------+----------------+
|        Cluster: HTC        |     Total SUs: 100000     |                |
+----------------------------+---------------------------+----------------+
|            User            |          SUs Used         |     % Used     |
+----------------------------+---------------------------+----------------+
|        clcgenomics         |             0             |      N/A       |
|           djp81            |             4             |      N/A       |
|          fangping          |            209            |      N/A       |
|          gnowmik           |             1             |      N/A       |
|          kimwong           |           15695           |       15       |
|           nlc60            |             4             |      N/A       |
|           yak73            |             7             |      N/A       |
|          bmooreii          |             0             |      N/A       |
|           chx33            |             0             |      N/A       |
|            fis7            |             0             |      N/A       |
|            jar7            |             0             |      N/A       |
|           ketan            |             0             |      N/A       |
|           leb140           |             0             |      N/A       |
|           mak189           |             0             |      N/A       |
|           sak236           |             0             |      N/A       |
|           shs159           |             0             |      N/A       |
+----------------------------+---------------------------+----------------+
|      Overall for HTC       |           15920           |       15       |
+----------------------------+---------------------------+----------------+
|                            |                           |                |
+----------------------------+---------------------------+----------------+
|        Floating SUs        |       SUs Remaining       |     % Used     |
+----------------------------+---------------------------+----------------+
|       *Floating SUs        |                           |                |
|       are applied on       |                           |                |
|       any cluster to       |           25000*          |       0        |
|     cover usage above      |                           |                |
|         Total SUs          |                           |                |
+----------------------------+---------------------------+----------------+
|      Aggregate Usage       |             7             |                |
+----------------------------+---------------------------+----------------+
```