### PR TITLE
Update output format for Investment table

### DIFF
--- a/bank/account_logic.py
+++ b/bank/account_logic.py
@@ -722,6 +722,7 @@ class AccountServices:
                                            f'    {recent_proposal_alloc_status}')
 
             # Proposal End Date as first row
+            output_table.title = f"{self._account_name} Proposal Information"
             output_table.add_row(['Proposal End Date:', proposal.end_date.strftime(settings.date_format), ""],
                                  divider=True)
 
@@ -830,23 +831,16 @@ class AccountServices:
             if not investments:
                 raise MissingInvestmentError('Account has no investments')
 
-            table = PrettyTable(header=False, padding_width=5)
-            table.add_row(['Investment ID',
-                           'Total Investment SUs',
-                           'Start Date',
-                           'Current SUs',
-                           'Withdrawn SUs',
-                           'Rollover SUs'])
+            table = PrettyTable(header=False, padding_width=5, max_width=80)
+            table.title =f"{self._account_name} Investment Information"
 
-            for inv in investments:
-                table.add_row([
-                    inv.id,
-                    inv.service_units,
-                    inv.start_date.strftime(settings.date_format),
-                    inv.current_sus,
-                    inv.withdrawn_sus,
-                    inv.withdrawn_sus])
+            for inv in investments: 
+                table.add_row(['Investment ID','Start Date','End Date'], divider=True)
+                table.add_row([inv.id, inv.start_date.strftime(settings.date_format), inv.end_date.strftime(settings.date_format)], divider=True)
 
+                table.add_row(['Total Service Units', 'Current SUs', 'Withdrawn SUs'], divider=True)
+                table.add_row([inv.service_units, inv.current_sus, inv.withdrawn_sus], divider=True)
+                table.add_row(['','',''], divider=True)
         return table
 
     def info(self) -> None:
@@ -854,6 +848,7 @@ class AccountServices:
 
         try:
             print(self._build_usage_table())
+            print("\n")
 
         except MissingProposalError as e:
             print(f'Account {self._account_name} has no active proposal: {str(e)}')


### PR DESCRIPTION
I wanted to make the Investment output a little easier to read, and a similar width to the Proposal table. I've added titles to each table as well and some spacing between them so they are easier to tell apart:

```
(bank_deploy) [root@moss bank]# crc-bank account info lchong
+--------------------------------------------------------------------------+
|                       lchong Proposal Information                        |
+----------------------------+----------------------------+----------------+
|     Proposal End Date:     |         04/04/2024         |                |
+----------------------------+----------------------------+----------------+
|        Proposal ID:        |             4              |                |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Cluster: SMP        |     Total SUs: 100000      |                |
+----------------------------+----------------------------+----------------+
|            User            |          SUs Used          |     % Used     |
+----------------------------+----------------------------+----------------+
|           atb43            |            729             |      N/A       |
|            dty7            |            1717            |       1        |
|           jml230           |           64835            |       64       |
|           lel178           |             1              |      N/A       |
|          marionlo          |            4757            |       4        |
|           mls333           |            1593            |       1        |
|           rca27            |           74753            |       74       |
|           ris130           |            217             |      N/A       |
+----------------------------+----------------------------+----------------+
|      Overall for SMP       |           148602           |      148       |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Cluster: MPI        |     Total SUs: 1325983     |                |
+----------------------------+----------------------------+----------------+
|            User            |          SUs Used          |     % Used     |
+----------------------------+----------------------------+----------------+
|           atb43            |            1184            |      N/A       |
|           jml230           |           66617            |       5        |
|           rca27            |           135508           |       10       |
+----------------------------+----------------------------+----------------+
|      Overall for MPI       |           203309           |       15       |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Cluster: GPU        |     Total SUs: 634351      |                |
+----------------------------+----------------------------+----------------+
|            User            |          SUs Used          |     % Used     |
+----------------------------+----------------------------+----------------+
|           atb43            |           36969            |       5        |
|           bwf15            |           21109            |       3        |
|            dty7            |           187764           |       29       |
|           jml230           |           220426           |       34       |
|          marionlo          |           27464            |       4        |
|           mls333           |            4819            |      N/A       |
|           ncf26            |           35800            |       5        |
+----------------------------+----------------------------+----------------+
|      Overall for GPU       |           534351           |       84       |
+----------------------------+----------------------------+----------------+
|                            |                            |                |
+----------------------------+----------------------------+----------------+
|        Floating SUs        |       SUs Remaining        |     % Used     |
+----------------------------+----------------------------+----------------+
|       *Floating SUs        |                            |                |
|       are applied on       |                            |                |
|       any cluster to       |             0*             |       0        |
|     cover usage above      |                            |                |
|         Total SUs          |                            |                |
+----------------------------+----------------------------+----------------+
|      Aggregate Usage       |             43             |                |
+----------------------------+----------------------------+----------------+


+---------------------------------------------------------------------------+
|                       lchong Investment Information                       |
+-----------------------------+---------------------+-----------------------+
|        Investment ID        |      Start Date     |        End Date       |
+-----------------------------+---------------------+-----------------------+
|              31             |      07/29/2016     |       07/29/2021      |
+-----------------------------+---------------------+-----------------------+
|     Total Service Units     |     Current SUs     |     Withdrawn SUs     |
+-----------------------------+---------------------+-----------------------+
|            744600           |        148920       |           -9          |
+-----------------------------+---------------------+-----------------------+
|                             |                     |                       |
+-----------------------------+---------------------+-----------------------+
|        Investment ID        |      Start Date     |        End Date       |
+-----------------------------+---------------------+-----------------------+
|              32             |      07/29/2016     |       07/29/2021      |
+-----------------------------+---------------------+-----------------------+
|     Total Service Units     |     Current SUs     |     Withdrawn SUs     |
+-----------------------------+---------------------+-----------------------+
|            148920           |        29784        |           -9          |
+-----------------------------+---------------------+-----------------------+
|                             |                     |                       |
+-----------------------------+---------------------+-----------------------+
```