### PR TITLE
Use billing instead of cpu/gpu for TRES limit

### DIFF
--- a/bank/system/slurm.py
+++ b/bank/system/slurm.py
@@ -146,10 +146,7 @@ class SlurmAccount:
             raise ClusterNotFoundError(f'Cluster {cluster} is not configured with Slurm')
 
         lock_state_int = 0 if lock_state else -1
-        ShellCmd(f'sacctmgr -i modify account where account={self.account_name} cluster={cluster} '
-                 f'set GrpTresRunMins=cpu={lock_state_int}').raise_if_err()
-        ShellCmd(f'sacctmgr -i modify account where account={self.account_name} cluster={cluster} '
-                 f'set GrpTresRunMins=gres/gpu={lock_state_int}').raise_if_err()
+        ShellCmd(f'sacctmgr -i modify account where account={self.account_name} cluster={cluster} set GrpTresRunMins=billing={lock_state_int}').raise_if_err()
 
     def get_cluster_usage_per_user(self, cluster: str, start: date, end: date, in_hours: bool = True) -> Dict[str, int]:
         """Return the raw account usage per user on a given cluster

--- a/bank/system/slurm.py
+++ b/bank/system/slurm.py
@@ -128,7 +128,7 @@ class SlurmAccount:
             raise ClusterNotFoundError(f'Cluster {cluster} is not configured with Slurm')
 
         cmd = f'sacctmgr -n -P show assoc account={self.account_name} format=GrpTresRunMins clusters={cluster}'
-        return 'cpu=0' in ShellCmd(cmd).out
+        return 'billing=0' in ShellCmd(cmd).out
 
     def set_locked_state(self, lock_state: bool, cluster: str) -> None:
         """Lock or unlock the current slurm account


### PR DESCRIPTION
This should fix the issues where accounts who are already locked on some cluster can't submit to their investment partitions and preempt partitions.